### PR TITLE
Remap refactor get leader key original action and handle plugins through mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Here's some ideas on what you can do with neovim integration:
 
 Custom remappings are defined on a per-mode basis.
 
-#### `"vim.insertModeKeyBindings"`/`"vim.normalModeKeyBindings"`/`"vim.visualModeKeyBindings"`
+#### `"vim.insertModeKeyBindings"`/`"vim.normalModeKeyBindings"`/`"vim.visualModeKeyBindings"`/`"vim.operatorPendingModeKeyBindings"`
 
-- Keybinding overrides to use for insert, normal, and visual modes.
+- Keybinding overrides to use for insert, normal, operatorPending and visual modes.
 - Bind `jj` to `<Esc>` in insert mode:
 
 ```json
@@ -179,7 +179,7 @@ Custom remappings are defined on a per-mode basis.
 - Bind `:` to show the command palette:
 
 ```json
-    "vim.normalModeKeyBindingsNonRecursive": [
+    "vim.normalModeKeyBindings": [
         {
             "before": [":"],
             "commands": [
@@ -192,7 +192,7 @@ Custom remappings are defined on a per-mode basis.
 - Bind `<leader>m` to add a bookmark and `<leader>b` to open the list of all bookmarks (using the [Bookmarks](https://marketplace.visualstudio.com/items?itemName=alefragnani.Bookmarks) extension):
 
 ```json
-    "vim.normalModeKeyBindingsNonRecursive": [
+    "vim.normalModeKeyBindings": [
         {
             "before": ["<leader>", "m"],
             "commands": [
@@ -211,7 +211,7 @@ Custom remappings are defined on a per-mode basis.
 - Bind `ZZ` to the vim command `:wq` (save and close the current file):
 
 ```json
-    "vim.normalModeKeyBindingsNonRecursive": [
+    "vim.normalModeKeyBindings": [
         {
             "before": ["Z", "Z"],
             "commands": [
@@ -224,7 +224,7 @@ Custom remappings are defined on a per-mode basis.
 - Bind `ctrl+n` to turn off search highlighting and `<leader>w` to save the current file:
 
 ```json
-    "vim.normalModeKeyBindingsNonRecursive": [
+    "vim.normalModeKeyBindings": [
         {
             "before":["<C-n>"],
             "commands": [
@@ -240,28 +240,36 @@ Custom remappings are defined on a per-mode basis.
     ]
 ```
 
-- Bind `p` in visual mode to paste without overriding the current register
+- Bind `{` to `w` in operator pending mode makes `y{` and `d{` work like `yw` and `dw` respectively.
 
 ```json
-    "vim.visualModeKeyBindingsNonRecursive": [
+    "vim.operatorPendingModeKeyBindings": [
         {
-            "before": [
-                "p",
-            ],
-            "after": [
-                "p",
-                "g",
-                "v",
-                "y"
-            ]
+            "before": ["{"],
+            "after": ["w"]
         }
-    ],
+    ]
+```
+
+- Bind `L` to `$` and `H` to `^` in operator pending mode makes `yL` and `dH` work like `yL` and `d^` respectively.
+
+```json
+    "vim.operatorPendingModeKeyBindings": [
+        {
+            "before": ["L"],
+            "after": ["$"]
+        },
+        {
+            "before": ["H"],
+            "after": ["^"]
+        }
+    ]
 ```
 
 - Bind `>` and `<` in visual mode to indent/outdent lines (repeatable)
 
 ```json
-    "vim.visualModeKeyBindingsNonRecursive": [
+    "vim.visualModeKeyBindings": [
         {
             "before": [
                 ">"
@@ -284,7 +292,7 @@ Custom remappings are defined on a per-mode basis.
 - Bind `<leader>vim` to clone this repository to the selected location.
 
 ```json
-    "vim.visualModeKeyBindingsNonRecursive": [
+    "vim.visualModeKeyBindings": [
         {
             "before": [
                 "<leader>", "v", "i", "m"
@@ -299,18 +307,51 @@ Custom remappings are defined on a per-mode basis.
     ]
 ```
 
-#### `"vim.insertModeKeyBindingsNonRecursive"`/`"normalModeKeyBindingsNonRecursive"`/`"visualModeKeyBindingsNonRecursive"`
+#### `"vim.insertModeKeyBindingsNonRecursive"`/`"normalModeKeyBindingsNonRecursive"`/`"visualModeKeyBindingsNonRecursive"`/`"operatorPendingModeKeyBindingsNonRecursive"`
 
 - Non-recursive keybinding overrides to use for insert, normal, and visual modes
-- _Example:_ Bind `j` to `gj`. Notice that if you attempted this binding normally, the j in gj would be expanded into gj, on and on forever. Stop this recursive expansion using insertModeKeyBindingsNonRecursive and/or normalModeKeyBindingNonRecursive.
+- _Example:_ Exchange the meaning of two keys like `j` to `k` and `k` to `j` to exchange the cursor up and down commands. Notice that if you attempted this binding normally, the `j` would be replaced with `k` and the `k` would be replaced with `j`, on and on forever. When this happens 'maxmapdepth' times (default 1000) the error message 'E223 Recursive Mapping' will be thrown. Stop this recursive expansion using the NonRecursive variation of the keybindings.
 
 ```json
     "vim.normalModeKeyBindingsNonRecursive": [
         {
             "before": ["j"],
-            "after": ["g", "j"]
+            "after": ["k"]
+        },
+        {
+            "before": ["k"],
+            "after": ["j"]
         }
     ]
+```
+
+- Bind `(` to 'i(' in operator pending mode makes 'y(' and 'c(' work like 'yi(' and 'ci(' respectively.
+
+```json
+    "vim.operatorPendingModeKeyBindingsNonRecursive": [
+        {
+            "before": ["("],
+            "after": ["i("]
+        }
+    ]
+```
+
+- Bind `p` in visual mode to paste without overriding the current register
+
+```json
+    "vim.visualModeKeyBindingsNonRecursive": [
+        {
+            "before": [
+                "p",
+            ],
+            "after": [
+                "p",
+                "g",
+                "v",
+                "y"
+            ]
+        }
+    ],
 ```
 
 #### Debugging Remappings
@@ -361,6 +402,7 @@ Configuration settings that have been copied from vim. Vim settings are loaded i
 | vim.smartcase    | Override the 'ignorecase' setting if search pattern contains uppercase characters                                                                                                                                                                                     | Boolean | true          |
 | vim.textwidth    | Width to word-wrap when using `gq`                                                                                                                                                                                                                                    | Number  | 80            |
 | vim.timeout      | Timeout in milliseconds for remapped commands                                                                                                                                                                                                                         | Number  | 1000          |
+| vim.maxmapdepth  | Maximum number of times a mapping is done without resulting in a character to be used. This normally catches endless mappings, like ":map x y" with ":map y x". It still does not catch ":map g wg", because the 'w' is used before the next mapping is done.         | Number  | 1000          |
 | vim.whichwrap    | Controls wrapping at beginning and end of line. Comma-separated set of keys that should wrap to next/previous line. Arrow keys are represented by `[` and `]` in insert mode, `<` and `>` in normal and visual mode. To wrap "everything", set this to `h,l,<,>,[,]`. | String  | ``            |
 | vim.report       | Threshold for reporting number of lines changed.                                                                                                                                                                                                                      | Number  | 2             |
 

--- a/extensionBase.ts
+++ b/extensionBase.ts
@@ -18,6 +18,7 @@ import { configuration } from './src/configuration/configuration';
 import { globalState } from './src/state/globalState';
 import { taskQueue } from './src/taskQueue';
 import { Register } from './src/register/register';
+import { SpecialKeys } from './src/util/specialKeys';
 
 let extensionContext: vscode.ExtensionContext;
 let previousActiveEditorId: EditorIdentity | undefined = undefined;
@@ -434,7 +435,13 @@ export async function activate(
   });
 
   for (const boundKey of configuration.boundKeyCombinations) {
-    registerCommand(context, boundKey.command, () => handleKeyEvent(`${boundKey.key}`));
+    registerCommand(context, boundKey.command, () => {
+      if (['<Esc>', '<C-c>'].includes(boundKey.key)) {
+        checkIfRecursiveRemapping(`${boundKey.key}`);
+      } else {
+        handleKeyEvent(`${boundKey.key}`);
+      }
+    });
   }
 
   // Initialize mode handler for current active Text Editor at startup.
@@ -468,11 +475,11 @@ async function toggleExtension(isDisabled: boolean, compositionState: Compositio
   }
   let mh = await getAndUpdateModeHandler();
   if (isDisabled) {
-    await mh.handleKeyEvent('<ExtensionDisable>');
+    await mh.handleKeyEvent(SpecialKeys.ExtensionDisable);
     compositionState.reset();
     ModeHandlerMap.clear();
   } else {
-    await mh.handleKeyEvent('<ExtensionEnable>');
+    await mh.handleKeyEvent(SpecialKeys.ExtensionEnable);
   }
 }
 
@@ -544,6 +551,15 @@ async function handleKeyEvent(key: string): Promise<void> {
   taskQueue.enqueueTask(async () => {
     await mh.handleKeyEvent(key);
   });
+}
+
+async function checkIfRecursiveRemapping(key: string): Promise<void> {
+  const mh = await getAndUpdateModeHandler();
+  if (mh.vimState.isCurrentlyPerformingRecursiveRemapping) {
+    mh.vimState.forceStopRecursiveRemapping = true;
+  } else {
+    handleKeyEvent(key);
+  }
 }
 
 function handleContentChangedFromDisk(document: vscode.TextDocument): void {

--- a/package.json
+++ b/package.json
@@ -416,6 +416,14 @@
           "type": "array",
           "markdownDescription": "Non-recursive remapped keys in Normal mode. Allows mapping to Vim commands or VS Code actions. See [README](https://github.com/VSCodeVim/Vim/#key-remapping) for details."
         },
+        "vim.operatorPendingModeKeyBindings": {
+          "type": "array",
+          "markdownDescription": "Remapped keys in OperatorPending mode. Allows mapping to Vim commands or VS Code actions. See [README](https://github.com/VSCodeVim/Vim/#key-remapping) for details."
+        },
+        "vim.operatorPendingModeKeyBindingsNonRecursive": {
+          "type": "array",
+          "markdownDescription": "Non-recursive remapped keys in OperatorPending mode. Allows mapping to Vim commands or VS Code actions. See [README](https://github.com/VSCodeVim/Vim/#key-remapping) for details."
+        },
         "vim.useCtrlKeys": {
           "type": "boolean",
           "markdownDescription": "Enable some Vim Ctrl key commands that override otherwise common operations, like `Ctrl+C`.",
@@ -497,6 +505,12 @@
         "vim.timeout": {
           "type": "number",
           "description": "Timeout in milliseconds for remapped commands.",
+          "default": 1000,
+          "minimum": 0
+        },
+        "vim.maxmapdepth": {
+          "type": "number",
+          "description": "Maximum number of times a mapping is done without resulting in a character to be used.",
           "default": 1000,
           "minimum": 0
         },

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -326,9 +326,15 @@ export function RegisterPluginAction(pluginName: string) {
       if (
         actionInstance.keys === undefined ||
         is2DArray(actionInstance.keys) ||
-        actionInstance.keys.length > 1
+        !actionInstance.keys[0].toLocaleLowerCase().startsWith('<plug>')
       ) {
         // action that can't be called directly or invalid plugin action key
+        continue;
+      }
+
+      if (actionInstance.pluginActionDefaultKeys.length === 0) {
+        // plugin action without default mappings. Can be mapped later by the user.
+        actions.push(action);
         continue;
       }
 
@@ -337,14 +343,14 @@ export function RegisterPluginAction(pluginName: string) {
         for (const keyset of actionInstance.pluginActionDefaultKeys) {
           remappings.push({
             before: keyset,
-            after: actionInstance.keys,
+            after: [actionInstance.keys[0]],
             plugin: pluginName,
           });
         }
       } else {
         remappings.push({
           before: actionInstance.pluginActionDefaultKeys,
-          after: actionInstance.keys,
+          after: [actionInstance.keys[0]],
           plugin: pluginName,
         });
       }

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -1,11 +1,11 @@
 import { Position } from '../common/motion/position';
 import { Range } from '../common/motion/range';
-import { Notation } from '../configuration/notation';
 import { isTextTransformation } from '../transformations/transformations';
 import { configuration } from './../configuration/configuration';
 import { Mode, isVisualMode } from './../mode/mode';
 import { VimState } from './../state/vimState';
-import { IKeyRemapping } from '../configuration/iconfiguration';
+import { Notation } from '../configuration/notation';
+import { Globals } from '../globals';
 
 export abstract class BaseAction {
   /**
@@ -352,16 +352,33 @@ export function RegisterPluginAction(pluginName: string) {
       // Create default mappings for the default modes. If the plugin creates another custom
       // mode we don't need to create mappings for that because only that plugin's actions
       // will apply for that mode.
+      // Also store the default mappings on 'Globals.mockConfigurationDefaultBindings' to be used
+      // when testing.
       if (mode === Mode.Normal) {
         configuration.defaultnormalModeKeyBindingsNonRecursive.push(...remappings);
+        Globals.mockConfigurationDefaultBindings.defaultNormalModeKeyBindingsNonRecursive.push(
+          ...remappings
+        );
       } else if (mode === Mode.Insert || mode === Mode.Replace) {
         configuration.defaultinsertModeKeyBindingsNonRecursive.push(...remappings);
+        Globals.mockConfigurationDefaultBindings.defaultInsertModeKeyBindingsNonRecursive.push(
+          ...remappings
+        );
       } else if (isVisualMode(mode)) {
         configuration.defaultvisualModeKeyBindingsNonRecursive.push(...remappings);
+        Globals.mockConfigurationDefaultBindings.defaultVisualModeKeyBindingsNonRecursive.push(
+          ...remappings
+        );
       } else if (mode === Mode.CommandlineInProgress || mode === Mode.SearchInProgressMode) {
         configuration.defaultcommandLineModeKeyBindingsNonRecursive.push(...remappings);
+        Globals.mockConfigurationDefaultBindings.defaultCommandLineModeKeyBindingsNonRecursive.push(
+          ...remappings
+        );
       } else if (mode === Mode.OperatorPendingMode) {
         configuration.defaultoperatorPendingModeKeyBindingsNonRecursive.push(...remappings);
+        Globals.mockConfigurationDefaultBindings.defaultOperatorPendingModeKeyBindingsNonRecursive.push(
+          ...remappings
+        );
       }
 
       actions.push(action);

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -61,7 +61,7 @@ export abstract class BaseAction {
     }
 
     return (
-      this.modes.includes(vimState.currentMode) &&
+      this.modes.includes(vimState.currentModeIncludingPseudoModes) &&
       BaseAction.CompareKeypressSequence(this.keys, keysPressed)
     );
   }
@@ -70,7 +70,7 @@ export abstract class BaseAction {
    * Could the user be in the process of doing this action.
    */
   public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    if (!this.modes.includes(vimState.currentMode)) {
+    if (!this.modes.includes(vimState.currentModeIncludingPseudoModes)) {
       return false;
     }
 
@@ -275,7 +275,7 @@ export function getRelevantAction(
 ): BaseAction | KeypressState {
   let isPotentialMatch = false;
 
-  const possibleActionsForMode = actionMap.get(vimState.currentMode) || [];
+  const possibleActionsForMode = actionMap.get(vimState.currentModeIncludingPseudoModes) || [];
   for (const actionType of possibleActionsForMode) {
     const action = new actionType();
     if (action.doesActionApply(vimState, keysPressed)) {

--- a/src/actions/base.ts
+++ b/src/actions/base.ts
@@ -53,7 +53,8 @@ export abstract class BaseAction {
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     if (
       this.mustBeFirstKey &&
-      vimState.recordedState.commandWithoutCountPrefix.length > keysPressed.length
+      (vimState.recordedState.commandWithoutCountPrefix.length > keysPressed.length ||
+        vimState.recordedState.operator)
     ) {
       return false;
     }
@@ -80,7 +81,8 @@ export abstract class BaseAction {
 
     if (
       this.mustBeFirstKey &&
-      vimState.recordedState.commandWithoutCountPrefix.length > keysPressed.length
+      (vimState.recordedState.commandWithoutCountPrefix.length > keysPressed.length ||
+        vimState.recordedState.operator)
     ) {
       return false;
     }

--- a/src/actions/baseMotion.ts
+++ b/src/actions/baseMotion.ts
@@ -42,7 +42,7 @@ export function failedMovement(vimState: VimState): IMovement {
 }
 
 export abstract class BaseMovement extends BaseAction {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
 
   isMotion = true;
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -184,6 +184,7 @@ class DisableExtension extends BaseCommand {
     Mode.EasyMotionMode,
     Mode.EasyMotionInputMode,
     Mode.SurroundInputMode,
+    Mode.OperatorPendingMode,
   ];
   keys = [SpecialKeys.ExtensionDisable];
 
@@ -206,7 +207,7 @@ class EnableExtension extends BaseCommand {
 
 @RegisterAction
 export class CommandNumber extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = ['<number>'];
   isCompleteAction = false;
   runsOnceForEveryCursor() {
@@ -396,6 +397,7 @@ class CommandEsc extends BaseCommand {
     Mode.SurroundInputMode,
     Mode.EasyMotionMode,
     Mode.EasyMotionInputMode,
+    Mode.OperatorPendingMode,
   ];
   keys = [['<Esc>'], ['<C-c>'], ['<C-[>']];
 

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -315,7 +315,7 @@ export class CommandQuitRecordMacro extends BaseCommand {
   keys = ['q'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    const existingMacro = (await Register.get(vimState, vimState.recordedMacro.registerName)).text;
+    const existingMacro = (await Register.get(vimState, vimState.recordedMacro.registerName))?.text;
     if (!(existingMacro instanceof RecordedState)) {
       return vimState;
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -32,6 +32,7 @@ import { StatusBar } from '../../statusBar';
 import { reportFileInfo, reportSearch } from '../../util/statusBarTextUtils';
 import { globalState } from '../../state/globalState';
 import { VimError, ErrorCode } from '../../error';
+import { SpecialKeys } from '../../util/specialKeys';
 import _ = require('lodash');
 
 export class DocumentContentChangeAction extends BaseAction {
@@ -184,7 +185,7 @@ class DisableExtension extends BaseCommand {
     Mode.EasyMotionInputMode,
     Mode.SurroundInputMode,
   ];
-  keys = ['<ExtensionDisable>'];
+  keys = [SpecialKeys.ExtensionDisable];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Disabled);
@@ -195,7 +196,7 @@ class DisableExtension extends BaseCommand {
 @RegisterAction
 class EnableExtension extends BaseCommand {
   modes = [Mode.Disabled];
-  keys = ['<ExtensionEnable>'];
+  keys = [SpecialKeys.ExtensionEnable];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await vimState.setCurrentMode(Mode.Normal);
@@ -1176,7 +1177,7 @@ export class CommandShowSearchHistory extends BaseCommand {
   }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    if (vimState.recordedState.commandList.includes('?')) {
+    if (this.keysPressed.includes('?')) {
       this.direction = SearchDirection.Backward;
     }
     vimState.recordedState.transformations.push({
@@ -2458,8 +2459,10 @@ export class ActionDeleteCharWithDeleteKey extends BaseCommand {
     // http://vimdoc.sourceforge.net/htmldoc/change.html#<Del>
     if (vimState.recordedState.count !== 0) {
       vimState.recordedState.count = Math.floor(vimState.recordedState.count / 10);
-      vimState.recordedState.actionKeys = vimState.recordedState.count.toString().split('');
-      vimState.recordedState.commandList = vimState.recordedState.count.toString().split('');
+
+      // Change actionsRunPressedKeys so that showCmd updates correctly
+      vimState.recordedState.actionsRunPressedKeys =
+        vimState.recordedState.count > 0 ? vimState.recordedState.count.toString().split('') : [];
       this.isCompleteAction = false;
       return vimState;
     }

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -951,7 +951,7 @@ async function createSearchStateAndMoveToMatch(args: {
 
 @RegisterAction
 class CommandSearchCurrentWordExactForward extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ['*'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
@@ -964,7 +964,7 @@ class CommandSearchCurrentWordExactForward extends BaseCommand {
 
 @RegisterAction
 class CommandSearchCurrentWordForward extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
   keys = ['g', '*'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
@@ -994,7 +994,7 @@ class CommandSearchVisualForward extends BaseCommand {
 
 @RegisterAction
 class CommandSearchCurrentWordExactBackward extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ['#'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
@@ -1007,7 +1007,7 @@ class CommandSearchCurrentWordExactBackward extends BaseCommand {
 
 @RegisterAction
 class CommandSearchCurrentWordBackward extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
   keys = ['g', '#'];
   isMotion = true;
   runsOnceForEachCountPrefix = true;
@@ -1037,7 +1037,7 @@ class CommandSearchVisualBackward extends BaseCommand {
 
 @RegisterAction
 export class CommandSearchForwards extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = ['/'];
   isMotion = true;
   isJump = true;
@@ -1061,7 +1061,7 @@ export class CommandSearchForwards extends BaseCommand {
 
 @RegisterAction
 export class CommandSearchBackwards extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = ['?'];
   isMotion = true;
   isJump = true;
@@ -1099,7 +1099,7 @@ export class MarkCommand extends BaseCommand {
 
 @RegisterAction
 class CommandShowCommandLine extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = [':'];
   runsOnceForEveryCursor() {
     return false;
@@ -1761,7 +1761,7 @@ async function selectLastSearchWord(
 
 @RegisterAction
 class CommandSelectNextLastSearchWord extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualBlock];
   keys = ['g', 'n'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -1771,7 +1771,7 @@ class CommandSelectNextLastSearchWord extends BaseCommand {
 
 @RegisterAction
 class CommandSelectPreviousLastSearchWord extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualBlock];
   keys = ['g', 'N'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -1940,7 +1940,7 @@ class CommandGoForwardInChangelist extends BaseCommand {
 
 @RegisterAction
 class CommandGoStartPrevOperatedText extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = [
     ['`', '['],
     ["'", '['],
@@ -1959,7 +1959,7 @@ class CommandGoStartPrevOperatedText extends BaseCommand {
 
 @RegisterAction
 class CommandGoEndPrevOperatedText extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
   keys = [
     ['`', ']'],
     ["'", ']'],
@@ -1978,7 +1978,7 @@ class CommandGoEndPrevOperatedText extends BaseCommand {
 
 @RegisterAction
 class CommandGoLastChange extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = [
     ['`', '.'],
     ["'", '.'],
@@ -2176,7 +2176,7 @@ class CommandNavigateForward extends BaseCommand {
 
 @RegisterAction
 class CommandNavigateLast extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ['`', '`'];
   runsOnceForEveryCursor() {
     return false;
@@ -2190,7 +2190,7 @@ class CommandNavigateLast extends BaseCommand {
 
 @RegisterAction
 class CommandNavigateLastBOL extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ["'", "'"];
   runsOnceForEveryCursor() {
     return false;

--- a/src/actions/commands/commandLine.ts
+++ b/src/actions/commands/commandLine.ts
@@ -505,8 +505,12 @@ class CommandInsertRegisterContentInCommandLine extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.registerName = this.keysPressed[1];
     const register = await Register.get(vimState);
-    let text: string;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    let text: string;
     if (register.text instanceof Array) {
       text = register.text.join('\n');
     } else if (register.text instanceof RecordedState) {
@@ -540,8 +544,12 @@ class CommandInsertRegisterContentInSearchMode extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.registerName = this.keysPressed[1];
     const register = await Register.get(vimState);
-    let text: string;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    let text: string;
     if (register.text instanceof Array) {
       text = register.text.join('\n');
     } else if (register.text instanceof RecordedState) {

--- a/src/actions/commands/insert.ts
+++ b/src/actions/commands/insert.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
 
-import * as error from '../../error';
-
 import { lineCompletionProvider } from '../../completion/lineCompletionProvider';
 import { RecordedState } from '../../state/recordedState';
 import { VimState } from '../../state/vimState';
@@ -23,6 +21,9 @@ import {
 } from './actions';
 import { DefaultDigraphs } from './digraphs';
 import { Clipboard } from '../../util/clipboard';
+import { StatusBar } from '../../statusBar';
+import { VimError, ErrorCode } from '../../error';
+import { error } from 'console';
 
 @RegisterAction
 class CommandEscInsertMode extends BaseCommand {
@@ -112,12 +113,16 @@ export class CommandInsertPreviousText extends BaseCommand {
   keys = ['<C-a>'];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    let lastInserted = (await Register.get(vimState, '.')).text as RecordedState;
-    if (!lastInserted.actionsRun) {
-      throw error.VimError.fromCode(error.ErrorCode.NoInsertedTextYet);
+    const register = await Register.get(vimState, '.');
+    if (
+      register === undefined ||
+      !(register.text instanceof RecordedState) ||
+      !register.text.actionsRun
+    ) {
+      throw VimError.fromCode(ErrorCode.NoInsertedTextYet);
     }
 
-    let actions = lastInserted.actionsRun.slice(0);
+    const actions = [...register.text.actionsRun];
     // let actions = Register.lastContentChange.actionsRun.slice(0);
     // The first action is entering Insert Mode, which is not necessary in this case
     actions.shift();
@@ -395,8 +400,12 @@ class CommandInsertRegisterContent extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     vimState.recordedState.registerName = this.keysPressed[1];
     const register = await Register.get(vimState);
-    let text: string;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    let text: string;
     if (register.text instanceof Array) {
       text = register.text.join('\n');
     } else if (register.text instanceof RecordedState) {

--- a/src/actions/commands/put.ts
+++ b/src/actions/commands/put.ts
@@ -1,13 +1,15 @@
 import { Position, PositionDiff, PositionDiffType, sorted } from '../../common/motion/position';
 import { configuration } from '../../configuration/configuration';
 import { isVisualMode, Mode } from '../../mode/mode';
-import { Register, RegisterMode } from '../../register/register';
+import { Register, RegisterMode, IRegisterContent } from '../../register/register';
 import { RecordedState } from '../../state/recordedState';
 import { VimState } from '../../state/vimState';
 import { TextEditor } from '../../textEditor';
 import { reportLinesChanged } from '../../util/statusBarTextUtils';
 import { BaseCommand, RegisterAction } from '../base';
 import * as operator from '../operator';
+import { StatusBar } from '../../statusBar';
+import { VimError, ErrorCode } from '../../error';
 
 /**
  * Flags used for executing PutCommand.
@@ -56,21 +58,20 @@ export class PutCommand extends BaseCommand {
 
   public static async getText(
     vimState: VimState,
+    registerContent: IRegisterContent,
     multicursorIndex: number | undefined
   ): Promise<string> {
-    const register = await Register.get(vimState);
-
     if (vimState.isMultiCursor) {
       if (multicursorIndex === undefined) {
         throw new Error('No multi-cursor index when calling PutCommand#getText');
       }
 
-      if (typeof register.text === 'object') {
-        return register.text[multicursorIndex];
+      if (typeof registerContent.text === 'object') {
+        return registerContent.text[multicursorIndex];
       }
     }
 
-    return register.text as string;
+    return registerContent.text as string;
   }
 
   public async exec(
@@ -79,6 +80,11 @@ export class PutCommand extends BaseCommand {
     options: IPutCommandOptions = {}
   ): Promise<VimState> {
     const register = await Register.get(vimState);
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
+
     const dest = options.pasteBeforeCursor ? position : position.getRight();
     const registerMode = options.forceLinewise ? RegisterMode.LineWise : register.registerMode;
 
@@ -107,7 +113,7 @@ export class PutCommand extends BaseCommand {
       );
     }
 
-    let text = await PutCommand.getText(vimState, this.multicursorIndex);
+    let text = await PutCommand.getText(vimState, register, this.multicursorIndex);
 
     const noPrevLine = vimState.cursorStartPosition.line === 0;
     const noNextLine = vimState.cursorStopPosition.line === TextEditor.getLineCount() - 1;
@@ -318,6 +324,12 @@ export class PutCommand extends BaseCommand {
   }
 
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
+    const register = await Register.get(vimState);
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
+
     const result = await super.execCount(position, vimState);
 
     if (
@@ -325,7 +337,7 @@ export class PutCommand extends BaseCommand {
       vimState.recordedState.count > 0
     ) {
       const numNewlines =
-        (await PutCommand.getText(vimState, this.multicursorIndex)).split('\n').length *
+        (await PutCommand.getText(vimState, register, this.multicursorIndex)).split('\n').length *
         vimState.recordedState.count;
 
       result.recordedState.transformations.push({
@@ -362,6 +374,12 @@ class PutCommandVisual extends BaseCommand {
   runsOnceForEachCountPrefix = true;
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    const register = await Register.get(vimState);
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
+
     let [start, end] = sorted(vimState.cursorStartPosition, vimState.cursorStopPosition);
     if (vimState.currentMode === Mode.VisualLine) {
       [start, end] = [start.getLineBegin(), end.getLineEnd()];
@@ -370,14 +388,13 @@ class PutCommandVisual extends BaseCommand {
     // If the to-be-inserted text is linewise, we have separate logic:
     // first delete the selection, then insert
     const oldMode = vimState.currentMode;
-    let register = await Register.get(vimState);
     if (register.registerMode === RegisterMode.LineWise) {
       const replaceRegisterName = vimState.recordedState.registerName;
-      const replaceRegister = await Register.get(vimState, replaceRegisterName);
+      const replaceRegister = (await Register.get(vimState, replaceRegisterName))!;
       vimState.recordedState.registerName = configuration.useSystemClipboard ? '*' : '"';
       await new operator.DeleteOperator(this.multicursorIndex).run(vimState, start, end, true);
       const deletedRegisterName = vimState.recordedState.registerName;
-      const deletedRegister = await Register.get(vimState, deletedRegisterName);
+      const deletedRegister = (await Register.get(vimState, deletedRegisterName))!;
       if (replaceRegisterName === deletedRegisterName) {
         Register.putByKey(replaceRegister.text, replaceRegisterName, replaceRegister.registerMode);
       }
@@ -432,8 +449,12 @@ class GPutCommand extends BaseCommand {
 
   public async execCount(position: Position, vimState: VimState): Promise<VimState> {
     const register = await Register.get(vimState);
-    let addedLinesCount: number;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    let addedLinesCount: number;
     if (register.text instanceof RecordedState) {
       vimState.recordedState.transformations.push({
         type: 'macro',
@@ -472,8 +493,12 @@ class GPutBeforeCommand extends BaseCommand {
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     await new PutCommand().exec(position, vimState, { pasteBeforeCursor: true });
     const register = await Register.get(vimState);
-    let addedLinesCount: number;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    let addedLinesCount: number;
     if (register.text instanceof RecordedState) {
       vimState.recordedState.transformations.push({
         type: 'macro',

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -17,7 +17,6 @@ import { VimError, ErrorCode } from '../error';
 import { BaseMovement, SelectionType, IMovement, isIMovement, failedMovement } from './baseMotion';
 import { globalState } from '../state/globalState';
 import { reportSearch } from '../util/statusBarTextUtils';
-import { SneakForward, SneakBackward } from './plugins/sneak';
 import { Notation } from '../configuration/notation';
 import { SearchDirection } from '../state/searchState';
 import { StatusBar } from '../statusBar';
@@ -662,18 +661,6 @@ class MoveFindForward extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
-    if (configuration.sneakReplacesF) {
-      const pos = await new SneakForward(
-        this.keysPressed.concat('\n'),
-        this.isRepeat
-      ).execActionWithCount(position, vimState, count);
-      if (vimState.recordedState.operator && !isIMovement(pos)) {
-        return pos.getRight();
-      }
-
-      return pos;
-    }
-
     count = count || 1;
     const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = findHelper(position, toFind, count, 'forward');
@@ -702,14 +689,6 @@ class MoveFindBackward extends BaseMovement {
     vimState: VimState,
     count: number
   ): Promise<Position | IMovement> {
-    if (configuration.sneakReplacesF) {
-      return new SneakBackward(this.keysPressed.concat('\n'), this.isRepeat).execActionWithCount(
-        position,
-        vimState,
-        count
-      );
-    }
-
     count = count || 1;
     const toFind = Notation.ToControlCharacter(this.keysPressed[1]);
     let result = findHelper(position, toFind, count, 'backward');

--- a/src/actions/motion.ts
+++ b/src/actions/motion.ts
@@ -65,13 +65,12 @@ abstract class MoveByScreenLine extends BaseMovement {
 
     await vscode.commands.executeCommand('cursorMove', {
       to: this.movementType,
-      select: vimState.currentMode !== Mode.Normal, // TODO: check if OperatorPendingMode needs this??
+      select: vimState.currentMode !== Mode.Normal,
       by: this.by,
       value: this.value * count,
     });
 
     if (vimState.currentMode === Mode.Normal) {
-      // TODO: when implementing full OperatorPendingMode check if this needs to change??
       return Position.FromVSCodePosition(vimState.editor.selection.active);
     } else {
       /**
@@ -129,7 +128,6 @@ abstract class MoveByScreenLineMaintainDesiredColumn extends MoveByScreenLine {
     let prevLine = vimState.editor.selection.active.line;
 
     if (vimState.currentMode !== Mode.Normal) {
-      // TODO: when implementing full OperatorPendingMode check if this needs to change??
       /**
        * As VIM and VSCode handle the end of selection index a little
        * differently we need to sometimes move the cursor at the end
@@ -151,13 +149,12 @@ abstract class MoveByScreenLineMaintainDesiredColumn extends MoveByScreenLine {
 
     await vscode.commands.executeCommand('cursorMove', {
       to: this.movementType,
-      select: vimState.currentMode !== Mode.Normal, // TODO: when implementing full OperatorPendingMode check if this needs to change??
+      select: vimState.currentMode !== Mode.Normal,
       by: this.by,
       value: this.value,
     });
 
     if (vimState.currentMode === Mode.Normal) {
-      // TODO: when implementing full OperatorPendingMode check if this needs to change??
       let returnedPos = Position.FromVSCodePosition(vimState.editor.selection.active);
       if (prevLine !== returnedPos.line) {
         returnedPos = returnedPos.withColumn(prevDesiredColumn);
@@ -1347,7 +1344,6 @@ class MoveParagraphEnd extends BaseMovement {
        */
       this.iteration++;
 
-      // TODO: when implementing full OperatorPendingMode check if this needs to change??
       const isLineWise = position.isLineBeginning() && vimState.currentMode === Mode.Normal;
 
       const isLastIteration = vimState.recordedState.count

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -321,7 +321,13 @@ export class YankOperator extends BaseOperator {
 @RegisterAction
 export class FilterOperator extends BaseOperator {
   public keys = ['!'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  public modes = [
+    Mode.Normal,
+    Mode.OperatorPendingMode,
+    Mode.Visual,
+    Mode.VisualLine,
+    Mode.VisualBlock,
+  ];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     [start, end] = sorted(start, end);

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -264,17 +264,6 @@ export class YankOperator extends BaseOperator {
   canBeRepeatedWithDot = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
-    // Hack to make Surround with y (which takes a motion) work.
-
-    if (vimState.surround) {
-      vimState.surround.range = new Range(start, end);
-      await vimState.setCurrentMode(Mode.SurroundInputMode);
-      vimState.cursorStopPosition = start;
-      vimState.cursorStartPosition = start;
-
-      return vimState;
-    }
-
     const originalMode = vimState.currentMode;
 
     [start, end] = sorted(start, end);

--- a/src/actions/operator.ts
+++ b/src/actions/operator.ts
@@ -123,7 +123,7 @@ export abstract class BaseOperator extends BaseAction {
 @RegisterAction
 export class DeleteOperator extends BaseOperator {
   public keys = ['d'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
 
   /**
    * Deletes from the position of start to 1 past the position of end.
@@ -260,7 +260,7 @@ export class DeleteOperatorVisual extends BaseOperator {
 @RegisterAction
 export class YankOperator extends BaseOperator {
   public keys = ['y'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
   canBeRepeatedWithDot = false;
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
@@ -404,7 +404,13 @@ export class ChangeOperatorSVisual extends BaseOperator {
 @RegisterAction
 export class FormatOperator extends BaseOperator {
   public keys = ['='];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  public modes = [
+    Mode.Normal,
+    Mode.OperatorPendingMode,
+    Mode.Visual,
+    Mode.VisualLine,
+    Mode.VisualBlock,
+  ];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     // = operates on complete lines
@@ -445,7 +451,7 @@ export class UpperCaseOperator extends BaseOperator {
 @RegisterAction
 export class UpperCaseWithMotion extends UpperCaseOperator {
   public keys = [['g', 'U']];
-  public modes = [Mode.Normal];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode];
 }
 
 @RegisterAction
@@ -490,7 +496,7 @@ export class LowerCaseOperator extends BaseOperator {
 @RegisterAction
 export class LowerCaseWithMotion extends LowerCaseOperator {
   public keys = [['g', 'u']];
-  public modes = [Mode.Normal];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode];
 }
 
 @RegisterAction
@@ -516,7 +522,7 @@ class LowerCaseVisualBlockOperator extends BaseOperator {
 
 @RegisterAction
 class IndentOperator extends BaseOperator {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ['>'];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
@@ -573,7 +579,7 @@ class IndentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
 
 @RegisterAction
 class OutdentOperator extends BaseOperator {
-  modes = [Mode.Normal];
+  modes = [Mode.Normal, Mode.OperatorPendingMode];
   keys = ['<'];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
@@ -624,7 +630,7 @@ class OutdentOperatorInVisualModesIsAWeirdSpecialCase extends BaseOperator {
 @RegisterAction
 export class ChangeOperator extends BaseOperator {
   public keys = ['c'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     const isEndOfLine = end.character === end.getLineEnd().character;
@@ -800,13 +806,19 @@ class ToggleCaseVisualBlockOperator extends BaseOperator {
 @RegisterAction
 class ToggleCaseWithMotion extends ToggleCaseOperator {
   public keys = [['g', '~']];
-  public modes = [Mode.Normal];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode];
 }
 
 @RegisterAction
 export class CommentOperator extends BaseOperator {
   public keys = ['g', 'c'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  public modes = [
+    Mode.Normal,
+    Mode.OperatorPendingMode,
+    Mode.Visual,
+    Mode.VisualLine,
+    Mode.VisualBlock,
+  ];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     vimState.editor.selection = new vscode.Selection(start.getLineBegin(), end.getLineEnd());
@@ -822,7 +834,13 @@ export class CommentOperator extends BaseOperator {
 @RegisterAction
 export class ROT13Operator extends BaseOperator {
   public keys = ['g', '?'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  public modes = [
+    Mode.Normal,
+    Mode.OperatorPendingMode,
+    Mode.Visual,
+    Mode.VisualLine,
+    Mode.VisualBlock,
+  ];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     let selections: vscode.Selection[];
@@ -875,7 +893,7 @@ export class ROT13Operator extends BaseOperator {
 @RegisterAction
 export class CommentBlockOperator extends BaseOperator {
   public keys = ['g', 'C'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
 
   public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
     if (vimState.currentMode === Mode.Normal) {
@@ -911,7 +929,7 @@ type CommentType = CommentTypeSingle | CommentTypeMultiLine;
 
 @RegisterAction
 class ActionVisualReflowParagraph extends BaseOperator {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
   keys = ['g', 'q'];
 
   public static CommentTypes: CommentType[] = [

--- a/src/actions/plugins/camelCaseMotion.ts
+++ b/src/actions/plugins/camelCaseMotion.ts
@@ -29,7 +29,7 @@ abstract class CamelCaseTextObjectMovement extends TextObjectMovement {
 }
 
 // based off of `MoveWordBegin`
-@RegisterPluginAction
+@RegisterPluginAction('camelcasemotion')
 class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'w'];
   keys = ['<CamelCaseMotion_w>'];
@@ -50,7 +50,7 @@ class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
 }
 
 // based off of `MoveWordEnd`
-@RegisterPluginAction
+@RegisterPluginAction('camelcasemotion')
 class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'e'];
   keys = ['<CamelCaseMotion_e>'];
@@ -67,7 +67,7 @@ class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
 }
 
 // based off of `MoveBeginningWord`
-@RegisterPluginAction
+@RegisterPluginAction('camelcasemotion')
 class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'b'];
   keys = ['<CamelCaseMotion_b>'];
@@ -78,7 +78,7 @@ class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
 }
 
 // based off of `SelectInnerWord`
-@RegisterPluginAction
+@RegisterPluginAction('camelcasemotion')
 class SelectInnerCamelCaseWord extends CamelCaseTextObjectMovement {
   modes = [Mode.OperatorPendingMode, Mode.Visual];
   pluginActionDefaultKeys = ['i', '<leader>', 'w'];

--- a/src/actions/plugins/camelCaseMotion.ts
+++ b/src/actions/plugins/camelCaseMotion.ts
@@ -1,5 +1,5 @@
 import { TextObjectMovement } from '../textobject';
-import { RegisterAction } from '../base';
+import { RegisterAction, BasePluginAction, RegisterPluginAction } from '../base';
 import { Mode } from '../../mode/mode';
 import { Position } from '../../common/motion/position';
 import { VimState } from '../../state/vimState';
@@ -29,9 +29,10 @@ abstract class CamelCaseTextObjectMovement extends TextObjectMovement {
 }
 
 // based off of `MoveWordBegin`
-@RegisterAction
+@RegisterPluginAction
 class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
-  keys = ['<leader>', 'w'];
+  pluginActionDefaultKeys = ['<leader>', 'w'];
+  keys = ['<CamelCaseMotion_w>'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     if (
@@ -49,9 +50,10 @@ class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
 }
 
 // based off of `MoveWordEnd`
-@RegisterAction
+@RegisterPluginAction
 class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
-  keys = ['<leader>', 'e'];
+  pluginActionDefaultKeys = ['<leader>', 'e'];
+  keys = ['<CamelCaseMotion_e>'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getCurrentCamelCaseWordEnd();
@@ -65,9 +67,10 @@ class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
 }
 
 // based off of `MoveBeginningWord`
-@RegisterAction
+@RegisterPluginAction
 class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
-  keys = ['<leader>', 'b'];
+  pluginActionDefaultKeys = ['<leader>', 'b'];
+  keys = ['<CamelCaseMotion_b>'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getCamelCaseWordLeft();
@@ -75,10 +78,11 @@ class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
 }
 
 // based off of `SelectInnerWord`
-@RegisterAction
+@RegisterPluginAction
 class SelectInnerCamelCaseWord extends CamelCaseTextObjectMovement {
-  modes = [Mode.Normal, Mode.Visual];
-  keys = ['i', '<leader>', 'w'];
+  modes = [Mode.OperatorPendingMode, Mode.Visual];
+  pluginActionDefaultKeys = ['i', '<leader>', 'w'];
+  keys = ['<CamelCaseMotion_iw>'];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     let start: Position;

--- a/src/actions/plugins/camelCaseMotion.ts
+++ b/src/actions/plugins/camelCaseMotion.ts
@@ -32,7 +32,7 @@ abstract class CamelCaseTextObjectMovement extends TextObjectMovement {
 @RegisterPluginAction('camelcasemotion')
 class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'w'];
-  keys = ['<CamelCaseMotion_w>'];
+  keys = ['<Plug>CamelCaseMotion_w'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     if (
@@ -53,7 +53,7 @@ class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
 @RegisterPluginAction('camelcasemotion')
 class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'e'];
-  keys = ['<CamelCaseMotion_e>'];
+  keys = ['<Plug>CamelCaseMotion_e'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getCurrentCamelCaseWordEnd();
@@ -70,7 +70,7 @@ class MoveCamelCaseWordEnd extends CamelCaseBaseMovement {
 @RegisterPluginAction('camelcasemotion')
 class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
   pluginActionDefaultKeys = ['<leader>', 'b'];
-  keys = ['<CamelCaseMotion_b>'];
+  keys = ['<Plug>CamelCaseMotion_b'];
 
   public async execAction(position: Position, vimState: VimState): Promise<Position> {
     return position.getCamelCaseWordLeft();
@@ -82,7 +82,7 @@ class MoveBeginningCamelCaseWord extends CamelCaseBaseMovement {
 class SelectInnerCamelCaseWord extends CamelCaseTextObjectMovement {
   modes = [Mode.OperatorPendingMode, Mode.Visual];
   pluginActionDefaultKeys = ['i', '<leader>', 'w'];
-  keys = ['<CamelCaseMotion_iw>'];
+  keys = ['<Plug>CamelCaseMotion_iw'];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
     let start: Position;

--- a/src/actions/plugins/easymotion/easymotion.cmd.ts
+++ b/src/actions/plugins/easymotion/easymotion.cmd.ts
@@ -109,6 +109,14 @@ abstract class BaseEasyMotionCommand extends BaseCommand {
       }
     }
   }
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]) {
+    return configuration.easymotion && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]) {
+    return configuration.easymotion && super.couldActionApply(vimState, keysPressed);
+  }
 }
 
 function getMatchesForString(
@@ -283,6 +291,14 @@ export class EasyMotionCharMoveCommandBase extends BaseCommand {
       await vimState.setCurrentMode(Mode.EasyMotionInputMode);
       return vimState;
     }
+  }
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]) {
+    return configuration.easymotion && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]) {
+    return configuration.easymotion && super.couldActionApply(vimState, keysPressed);
   }
 }
 

--- a/src/actions/plugins/easymotion/easymotion.cmd.ts
+++ b/src/actions/plugins/easymotion/easymotion.cmd.ts
@@ -26,7 +26,8 @@ export function buildTriggerKeys(trigger: EasymotionTrigger) {
 }
 
 abstract class BaseEasyMotionCommand extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  pluginActionDefaultKeys: string[] = [];
 
   private _baseOptions: EasyMotionMoveOptionsBase;
 
@@ -36,7 +37,7 @@ abstract class BaseEasyMotionCommand extends BaseCommand {
     super();
     this._baseOptions = baseOptions;
     if (trigger) {
-      this.keys = buildTriggerKeys(trigger);
+      this.pluginActionDefaultKeys = buildTriggerKeys(trigger);
     }
   }
 
@@ -269,13 +270,14 @@ export class SearchByNCharCommand extends BaseEasyMotionCommand implements EasyM
 }
 
 export class EasyMotionCharMoveCommandBase extends BaseCommand {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
+  pluginActionDefaultKeys: string[] = [];
   private _action: EasyMotionSearchAction;
 
   constructor(trigger: EasymotionTrigger, action: EasyMotionSearchAction) {
     super();
     this._action = action;
-    this.keys = buildTriggerKeys(trigger);
+    this.pluginActionDefaultKeys = buildTriggerKeys(trigger);
   }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {

--- a/src/actions/plugins/easymotion/registerMoveActions.ts
+++ b/src/actions/plugins/easymotion/registerMoveActions.ts
@@ -1,4 +1,4 @@
-import { RegisterAction } from './../../base';
+import { RegisterAction, RegisterPluginAction } from './../../base';
 import {
   EasyMotionCharMoveCommandBase,
   EasyMotionLineMoveCommandBase,
@@ -9,8 +9,9 @@ import {
 
 // EasyMotion n-char-move command
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-sn)>'];
   constructor() {
     super({ key: '/' }, new SearchByNCharCommand());
   }
@@ -18,29 +19,33 @@ class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
 
 // EasyMotion char-move commands
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharSearchCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-s2)>'];
   constructor() {
     super({ key: '2s' }, new SearchByCharCommand({ charCount: 2 }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharFindForwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-f2)>'];
   constructor() {
     super({ key: '2f' }, new SearchByCharCommand({ charCount: 2, searchOptions: 'min' }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharFindBackwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-F2)>'];
   constructor() {
     super({ key: '2F' }, new SearchByCharCommand({ charCount: 2, searchOptions: 'max' }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-t2)>'];
   constructor() {
     super(
       { key: '2t' },
@@ -51,8 +56,9 @@ class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveComm
 
 // easymotion-bd-t2
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-bd-t2)>'];
   constructor() {
     super(
       { key: 'bd2t', leaderCount: 3 },
@@ -61,8 +67,9 @@ class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMo
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-T2)>'];
   constructor() {
     super(
       { key: '2T' },
@@ -71,29 +78,33 @@ class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase 
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionSearchCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-s)>'];
   constructor() {
     super({ key: 's' }, new SearchByCharCommand({ charCount: 1 }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionFindForwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-f)>'];
   constructor() {
     super({ key: 'f' }, new SearchByCharCommand({ charCount: 1, searchOptions: 'min' }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionFindBackwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-F)>'];
   constructor() {
     super({ key: 'F' }, new SearchByCharCommand({ charCount: 1, searchOptions: 'max' }));
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-t)>'];
   constructor() {
     super(
       { key: 't' },
@@ -104,8 +115,9 @@ class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase
 
 // easymotion-bd-t
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-bd-t)>'];
   constructor() {
     super(
       { key: 'bdt', leaderCount: 3 },
@@ -114,8 +126,9 @@ class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveComma
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
+  keys = ['<(easymotion-T)>'];
   constructor() {
     super(
       { key: 'T' },
@@ -126,8 +139,9 @@ class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
 
 // EasyMotion word-move commands
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-w)>'];
   constructor() {
     super({ key: 'w' }, { searchOptions: 'min' });
   }
@@ -135,22 +149,25 @@ class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase
 
 // easymotion-bd-w
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionStartOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-bd-w)>'];
   constructor() {
     super({ key: 'bdw', leaderCount: 3 });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionLineForward extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-lineforward)>'];
   constructor() {
     super({ key: 'l' }, { jumpToAnywhere: true, searchOptions: 'min', labelPosition: 'after' });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-linebackward)>'];
   constructor() {
     super({ key: 'h' }, { jumpToAnywhere: true, searchOptions: 'max', labelPosition: 'after' });
   }
@@ -158,15 +175,17 @@ class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
 
 // easymotion "JumpToAnywhere" motion
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionJumpToAnywhereCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-jumptoanywhere)>'];
   constructor() {
     super({ key: 'j', leaderCount: 3 }, { jumpToAnywhere: true, labelPosition: 'after' });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-e)>'];
   constructor() {
     super({ key: 'e' }, { searchOptions: 'min', labelPosition: 'after' });
   }
@@ -174,22 +193,25 @@ class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
 
 // easymotion-bd-e
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionEndOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-bd-e)>'];
   constructor() {
     super({ key: 'bde', leaderCount: 3 }, { labelPosition: 'after' });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionBeginningWordCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-b)>'];
   constructor() {
     super({ key: 'b' }, { searchOptions: 'max' });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
+  keys = ['<(easymotion-ge)>'];
   constructor() {
     super({ key: 'ge' }, { searchOptions: 'max', labelPosition: 'after' });
   }
@@ -197,15 +219,17 @@ class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
 
 // EasyMotion line-move commands
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionStartOfLineForwardsCommand extends EasyMotionLineMoveCommandBase {
+  keys = ['<(easymotion-j)>'];
   constructor() {
     super({ key: 'j' }, { searchOptions: 'min' });
   }
 }
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBase {
+  keys = ['<(easymotion-k)>'];
   constructor() {
     super({ key: 'k' }, { searchOptions: 'max' });
   }
@@ -213,8 +237,9 @@ class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBas
 
 // easymotion-bd-jk
 
-@RegisterAction
+@RegisterPluginAction
 class EasyMotionStartOfLineBidirectionalCommand extends EasyMotionLineMoveCommandBase {
+  keys = ['<(easymotion-bd-jk)>'];
   constructor() {
     super({ key: 'bdjk', leaderCount: 3 });
   }

--- a/src/actions/plugins/easymotion/registerMoveActions.ts
+++ b/src/actions/plugins/easymotion/registerMoveActions.ts
@@ -9,7 +9,7 @@ import {
 
 // EasyMotion n-char-move command
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-sn)>'];
   constructor() {
@@ -19,7 +19,7 @@ class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
 
 // EasyMotion char-move commands
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharSearchCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-s2)>'];
   constructor() {
@@ -27,7 +27,7 @@ class EasyMotionTwoCharSearchCommand extends EasyMotionCharMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharFindForwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-f2)>'];
   constructor() {
@@ -35,7 +35,7 @@ class EasyMotionTwoCharFindForwardCommand extends EasyMotionCharMoveCommandBase 
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharFindBackwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-F2)>'];
   constructor() {
@@ -43,7 +43,7 @@ class EasyMotionTwoCharFindBackwardCommand extends EasyMotionCharMoveCommandBase
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-t2)>'];
   constructor() {
@@ -56,7 +56,7 @@ class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveComm
 
 // easymotion-bd-t2
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-bd-t2)>'];
   constructor() {
@@ -67,7 +67,7 @@ class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMo
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-T2)>'];
   constructor() {
@@ -78,7 +78,7 @@ class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase 
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionSearchCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-s)>'];
   constructor() {
@@ -86,7 +86,7 @@ class EasyMotionSearchCommand extends EasyMotionCharMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionFindForwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-f)>'];
   constructor() {
@@ -94,7 +94,7 @@ class EasyMotionFindForwardCommand extends EasyMotionCharMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionFindBackwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-F)>'];
   constructor() {
@@ -102,7 +102,7 @@ class EasyMotionFindBackwardCommand extends EasyMotionCharMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-t)>'];
   constructor() {
@@ -115,7 +115,7 @@ class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase
 
 // easymotion-bd-t
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-bd-t)>'];
   constructor() {
@@ -126,7 +126,7 @@ class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveComma
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
   keys = ['<(easymotion-T)>'];
   constructor() {
@@ -139,7 +139,7 @@ class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
 
 // EasyMotion word-move commands
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-w)>'];
   constructor() {
@@ -149,7 +149,7 @@ class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase
 
 // easymotion-bd-w
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionStartOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-bd-w)>'];
   constructor() {
@@ -157,7 +157,7 @@ class EasyMotionStartOfWordBidirectionalCommand extends EasyMotionWordMoveComman
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionLineForward extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-lineforward)>'];
   constructor() {
@@ -165,7 +165,7 @@ class EasyMotionLineForward extends EasyMotionWordMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-linebackward)>'];
   constructor() {
@@ -175,7 +175,7 @@ class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
 
 // easymotion "JumpToAnywhere" motion
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionJumpToAnywhereCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-jumptoanywhere)>'];
   constructor() {
@@ -183,7 +183,7 @@ class EasyMotionJumpToAnywhereCommand extends EasyMotionWordMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-e)>'];
   constructor() {
@@ -193,7 +193,7 @@ class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
 
 // easymotion-bd-e
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionEndOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-bd-e)>'];
   constructor() {
@@ -201,7 +201,7 @@ class EasyMotionEndOfWordBidirectionalCommand extends EasyMotionWordMoveCommandB
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionBeginningWordCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-b)>'];
   constructor() {
@@ -209,7 +209,7 @@ class EasyMotionBeginningWordCommand extends EasyMotionWordMoveCommandBase {
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
   keys = ['<(easymotion-ge)>'];
   constructor() {
@@ -219,7 +219,7 @@ class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
 
 // EasyMotion line-move commands
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineForwardsCommand extends EasyMotionLineMoveCommandBase {
   keys = ['<(easymotion-j)>'];
   constructor() {
@@ -227,7 +227,7 @@ class EasyMotionStartOfLineForwardsCommand extends EasyMotionLineMoveCommandBase
   }
 }
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBase {
   keys = ['<(easymotion-k)>'];
   constructor() {
@@ -237,7 +237,7 @@ class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBas
 
 // easymotion-bd-jk
 
-@RegisterPluginAction
+@RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineBidirectionalCommand extends EasyMotionLineMoveCommandBase {
   keys = ['<(easymotion-bd-jk)>'];
   constructor() {

--- a/src/actions/plugins/easymotion/registerMoveActions.ts
+++ b/src/actions/plugins/easymotion/registerMoveActions.ts
@@ -11,7 +11,7 @@ import {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-sn)>'];
+  keys = ['<Plug>(easymotion-sn)'];
   constructor() {
     super({ key: '/' }, new SearchByNCharCommand());
   }
@@ -21,7 +21,7 @@ class EasyMotionNCharSearchCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharSearchCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-s2)>'];
+  keys = ['<Plug>(easymotion-s2)'];
   constructor() {
     super({ key: '2s' }, new SearchByCharCommand({ charCount: 2 }));
   }
@@ -29,7 +29,7 @@ class EasyMotionTwoCharSearchCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharFindForwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-f2)>'];
+  keys = ['<Plug>(easymotion-f2)'];
   constructor() {
     super({ key: '2f' }, new SearchByCharCommand({ charCount: 2, searchOptions: 'min' }));
   }
@@ -37,7 +37,7 @@ class EasyMotionTwoCharFindForwardCommand extends EasyMotionCharMoveCommandBase 
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharFindBackwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-F2)>'];
+  keys = ['<Plug>(easymotion-F2)'];
   constructor() {
     super({ key: '2F' }, new SearchByCharCommand({ charCount: 2, searchOptions: 'max' }));
   }
@@ -45,7 +45,7 @@ class EasyMotionTwoCharFindBackwardCommand extends EasyMotionCharMoveCommandBase
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-t2)>'];
+  keys = ['<Plug>(easymotion-t2)'];
   constructor() {
     super(
       { key: '2t' },
@@ -58,7 +58,7 @@ class EasyMotionTwoCharTilCharacterForwardCommand extends EasyMotionCharMoveComm
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-bd-t2)>'];
+  keys = ['<Plug>(easymotion-bd-t2)'];
   constructor() {
     super(
       { key: 'bd2t', leaderCount: 3 },
@@ -69,7 +69,7 @@ class EasyMotionTwoCharTilCharacterBidirectionalCommand extends EasyMotionCharMo
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-T2)>'];
+  keys = ['<Plug>(easymotion-T2)'];
   constructor() {
     super(
       { key: '2T' },
@@ -80,7 +80,7 @@ class EasyMotionTwoCharTilBackwardCommand extends EasyMotionCharMoveCommandBase 
 
 @RegisterPluginAction('easymotion')
 class EasyMotionSearchCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-s)>'];
+  keys = ['<Plug>(easymotion-s)'];
   constructor() {
     super({ key: 's' }, new SearchByCharCommand({ charCount: 1 }));
   }
@@ -88,7 +88,7 @@ class EasyMotionSearchCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionFindForwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-f)>'];
+  keys = ['<Plug>(easymotion-f)'];
   constructor() {
     super({ key: 'f' }, new SearchByCharCommand({ charCount: 1, searchOptions: 'min' }));
   }
@@ -96,7 +96,7 @@ class EasyMotionFindForwardCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionFindBackwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-F)>'];
+  keys = ['<Plug>(easymotion-F)'];
   constructor() {
     super({ key: 'F' }, new SearchByCharCommand({ charCount: 1, searchOptions: 'max' }));
   }
@@ -104,7 +104,7 @@ class EasyMotionFindBackwardCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-t)>'];
+  keys = ['<Plug>(easymotion-t)'];
   constructor() {
     super(
       { key: 't' },
@@ -117,7 +117,7 @@ class EasyMotionTilCharacterForwardCommand extends EasyMotionCharMoveCommandBase
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-bd-t)>'];
+  keys = ['<Plug>(easymotion-bd-t)'];
   constructor() {
     super(
       { key: 'bdt', leaderCount: 3 },
@@ -128,7 +128,7 @@ class EasyMotionTilCharacterBidirectionalCommand extends EasyMotionCharMoveComma
 
 @RegisterPluginAction('easymotion')
 class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
-  keys = ['<(easymotion-T)>'];
+  keys = ['<Plug>(easymotion-T)'];
   constructor() {
     super(
       { key: 'T' },
@@ -141,7 +141,7 @@ class EasyMotionTilBackwardCommand extends EasyMotionCharMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-w)>'];
+  keys = ['<Plug>(easymotion-w)'];
   constructor() {
     super({ key: 'w' }, { searchOptions: 'min' });
   }
@@ -151,7 +151,7 @@ class EasyMotionStartOfWordForwardsCommand extends EasyMotionWordMoveCommandBase
 
 @RegisterPluginAction('easymotion')
 class EasyMotionStartOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-bd-w)>'];
+  keys = ['<Plug>(easymotion-bd-w)'];
   constructor() {
     super({ key: 'bdw', leaderCount: 3 });
   }
@@ -159,7 +159,7 @@ class EasyMotionStartOfWordBidirectionalCommand extends EasyMotionWordMoveComman
 
 @RegisterPluginAction('easymotion')
 class EasyMotionLineForward extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-lineforward)>'];
+  keys = ['<Plug>(easymotion-lineforward)'];
   constructor() {
     super({ key: 'l' }, { jumpToAnywhere: true, searchOptions: 'min', labelPosition: 'after' });
   }
@@ -167,7 +167,7 @@ class EasyMotionLineForward extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-linebackward)>'];
+  keys = ['<Plug>(easymotion-linebackward)'];
   constructor() {
     super({ key: 'h' }, { jumpToAnywhere: true, searchOptions: 'max', labelPosition: 'after' });
   }
@@ -177,7 +177,7 @@ class EasyMotionLineBackward extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionJumpToAnywhereCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-jumptoanywhere)>'];
+  keys = ['<Plug>(easymotion-jumptoanywhere)'];
   constructor() {
     super({ key: 'j', leaderCount: 3 }, { jumpToAnywhere: true, labelPosition: 'after' });
   }
@@ -185,7 +185,7 @@ class EasyMotionJumpToAnywhereCommand extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-e)>'];
+  keys = ['<Plug>(easymotion-e)'];
   constructor() {
     super({ key: 'e' }, { searchOptions: 'min', labelPosition: 'after' });
   }
@@ -195,7 +195,7 @@ class EasyMotionEndOfWordForwardsCommand extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionEndOfWordBidirectionalCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-bd-e)>'];
+  keys = ['<Plug>(easymotion-bd-e)'];
   constructor() {
     super({ key: 'bde', leaderCount: 3 }, { labelPosition: 'after' });
   }
@@ -203,7 +203,7 @@ class EasyMotionEndOfWordBidirectionalCommand extends EasyMotionWordMoveCommandB
 
 @RegisterPluginAction('easymotion')
 class EasyMotionBeginningWordCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-b)>'];
+  keys = ['<Plug>(easymotion-b)'];
   constructor() {
     super({ key: 'b' }, { searchOptions: 'max' });
   }
@@ -211,7 +211,7 @@ class EasyMotionBeginningWordCommand extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
-  keys = ['<(easymotion-ge)>'];
+  keys = ['<Plug>(easymotion-ge)'];
   constructor() {
     super({ key: 'ge' }, { searchOptions: 'max', labelPosition: 'after' });
   }
@@ -221,7 +221,7 @@ class EasyMotionEndBackwardCommand extends EasyMotionWordMoveCommandBase {
 
 @RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineForwardsCommand extends EasyMotionLineMoveCommandBase {
-  keys = ['<(easymotion-j)>'];
+  keys = ['<Plug>(easymotion-j)'];
   constructor() {
     super({ key: 'j' }, { searchOptions: 'min' });
   }
@@ -229,7 +229,7 @@ class EasyMotionStartOfLineForwardsCommand extends EasyMotionLineMoveCommandBase
 
 @RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBase {
-  keys = ['<(easymotion-k)>'];
+  keys = ['<Plug>(easymotion-k)'];
   constructor() {
     super({ key: 'k' }, { searchOptions: 'max' });
   }
@@ -239,7 +239,7 @@ class EasyMotionStartOfLineBackwordsCommand extends EasyMotionLineMoveCommandBas
 
 @RegisterPluginAction('easymotion')
 class EasyMotionStartOfLineBidirectionalCommand extends EasyMotionLineMoveCommandBase {
-  keys = ['<(easymotion-bd-jk)>'];
+  keys = ['<Plug>(easymotion-bd-jk)'];
   constructor() {
     super({ key: 'bdjk', leaderCount: 3 });
   }

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -12,7 +12,7 @@ import { BaseCommand } from '../commands/actions';
 @RegisterPluginAction('replacewithregister')
 export class ReplaceOperator extends BaseOperator {
   public pluginActionDefaultKeys = ['g', 'r'];
-  public keys = ['<ReplaceWithRegisterOperator>'];
+  public keys = ['<Plug>ReplaceWithRegisterOperator'];
   public modes = [Mode.Normal];
 
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
@@ -40,7 +40,7 @@ export class ReplaceOperator extends BaseOperator {
 @RegisterPluginAction('replacewithregister')
 export class ReplaceOperatorLine extends BaseCommand {
   public pluginActionDefaultKeys = ['g', 'r', 'r'];
-  public keys = ['<ReplaceWithRegisterLine>'];
+  public keys = ['<Plug>ReplaceWithRegisterLine'];
   public modes = [Mode.Normal];
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
@@ -59,7 +59,7 @@ export class ReplaceOperatorLine extends BaseCommand {
 @RegisterPluginAction('replacewithregister')
 export class ReplaceOperatorVisual extends ReplaceOperator {
   public pluginActionDefaultKeys = ['g', 'r'];
-  public keys = ['<ReplaceWithRegisterVisual>'];
+  public keys = ['<Plug>ReplaceWithRegisterVisual'];
   public modes = [Mode.Visual, Mode.VisualLine];
 }
 
@@ -73,7 +73,7 @@ const updateCursorPosition = (
   } = vimState;
   const lines = replaceWith.split('\n');
   const wasRunAsLineAction =
-    actionKeys.indexOf('<ReplaceWithRegisterLine>') === 0 && actionKeys.length === 1; // ie. grr
+    actionKeys.indexOf('<Plug>ReplaceWithRegisterLine') === 0 && actionKeys.length === 1; // ie. grr
   const registerAndRangeAreSingleLines = lines.length === 1 && range.isSingleLine;
   const singleLineAction = registerAndRangeAreSingleLines && !wasRunAsLineAction;
 

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -11,7 +11,7 @@ import { RegisterAction } from './../base';
 @RegisterAction
 export class ReplaceOperator extends BaseOperator {
   public keys = ['g', 'r'];
-  public modes = [Mode.Normal, Mode.Visual, Mode.VisualLine];
+  public modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual, Mode.VisualLine];
 
   public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
     return configuration.replaceWithRegister && super.doesActionApply(vimState, keysPressed);

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -6,8 +6,7 @@ import { Register, RegisterMode } from '../../register/register';
 import { VimState } from '../../state/vimState';
 import { TextEditor } from '../../textEditor';
 import { BaseOperator } from '../operator';
-import { RegisterAction, RegisterPluginAction } from './../base';
-import { BaseCommand } from '../commands/actions';
+import { RegisterAction, RegisterPluginAction, BaseCommand } from './../base';
 
 @RegisterPluginAction('replacewithregister')
 export class ReplaceOperator extends BaseOperator {

--- a/src/actions/plugins/replaceWithRegister.ts
+++ b/src/actions/plugins/replaceWithRegister.ts
@@ -7,6 +7,8 @@ import { VimState } from '../../state/vimState';
 import { TextEditor } from '../../textEditor';
 import { BaseOperator } from '../operator';
 import { RegisterAction } from './../base';
+import { StatusBar } from '../../statusBar';
+import { VimError, ErrorCode } from '../../error';
 
 @RegisterAction
 export class ReplaceOperator extends BaseOperator {
@@ -27,8 +29,12 @@ export class ReplaceOperator extends BaseOperator {
         ? new vscode.Range(start.getLineBegin(), end.getLineEndIncludingEOL())
         : new vscode.Range(start, end.getRight());
     const register = await Register.get(vimState);
-    const replaceWith = register.text as string;
+    if (register === undefined) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.NothingInRegister));
+      return vimState;
+    }
 
+    const replaceWith = register.text as string;
     await TextEditor.replace(range, replaceWith);
     await vimState.setCurrentMode(Mode.Normal);
     return updateCursorPosition(vimState, range, replaceWith);

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -146,7 +146,7 @@ class CommandSurroundModeRepeat extends BaseMovement {
 
 @RegisterAction
 class CommandSurroundModeStart extends BaseCommand {
-  modes = [Mode.Normal];
+  modes = [Mode.OperatorPendingMode];
   keys = ['s'];
   isCompleteAction = false;
   runsOnceForEveryCursor() {

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -3,9 +3,9 @@ import { PairMatcher } from './../../common/matching/matcher';
 import { Position, PositionDiff, sorted } from './../../common/motion/position';
 import { Range } from './../../common/motion/range';
 import { configuration } from './../../configuration/configuration';
-import { Mode } from './../../mode/mode';
+import { Mode, isVisualMode } from './../../mode/mode';
 import { TextEditor } from './../../textEditor';
-import { RegisterAction, BaseCommand } from './../base';
+import { RegisterAction, RegisterPluginAction, BaseCommand } from './../base';
 import { BaseMovement, IMovement } from '../baseMotion';
 import {
   MoveABacktick,
@@ -20,7 +20,7 @@ import {
   MoveInsideTag,
   MoveQuoteMatch,
 } from '../motion';
-import { ChangeOperator, DeleteOperator, YankOperator } from './../operator';
+import { ChangeOperator, DeleteOperator, YankOperator, BaseOperator } from './../operator';
 import {
   SelectInnerBigWord,
   SelectInnerParagraph,
@@ -28,6 +28,7 @@ import {
   SelectInnerWord,
   TextObjectMovement,
 } from './../textobject';
+import { RegisterMode } from '../../register/register';
 
 @RegisterAction
 class CommandSurroundAddTarget extends BaseCommand {
@@ -115,139 +116,146 @@ class CommandSurroundAddTarget extends BaseCommand {
   }
 }
 
-// Aaaaagghhhh. I tried so hard to make surround an operator to make use of our
-// sick new operator repeat structure, but there's just no clean way to do it.
-// In the future, if somebody wants to refactor Surround, the big problem for
-// why it's so weird is that typing `ys` loads up the Yank operator first,
-// which prevents us from making a surround operator that's `ys` or something.
-// You'd need to refactor our keybinding handling to "give up" keystrokes if it
-// can't find a match.
-
-@RegisterAction
-class CommandSurroundModeRepeat extends BaseMovement {
-  modes = [Mode.OperatorPendingMode];
-  keys = ['s'];
-  isCompleteAction = false;
-  runsOnceForEveryCursor() {
-    return false;
-  }
-
-  public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
-    return {
-      start: position.getLineBeginRespectingIndent(),
-      stop: position.getLineEnd().getLastWordEnd().getRight(),
-    };
-  }
-
-  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    return super.doesActionApply(vimState, keysPressed) && vimState.surround !== undefined;
-  }
-}
-
-@RegisterAction
-class CommandSurroundModeStart extends BaseCommand {
-  modes = [Mode.OperatorPendingMode];
-  keys = ['s'];
-  isCompleteAction = false;
-  runsOnceForEveryCursor() {
-    return false;
-  }
-
-  public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    // Only execute the action if the configuration is set
-    if (!configuration.surround) {
-      return vimState;
-    }
-
-    const operator = vimState.recordedState.operator;
-    let operatorString: 'change' | 'delete' | 'yank' | undefined;
-
-    if (operator instanceof ChangeOperator) {
-      operatorString = 'change';
-    } else if (operator instanceof DeleteOperator) {
-      operatorString = 'delete';
-    } else if (operator instanceof YankOperator) {
-      operatorString = 'yank';
-    }
-
-    if (!operatorString) {
-      return vimState;
-    }
-
-    // Start to record the keys to store for playback of surround using dot
-    vimState.recordedState.surroundKeys.push(vimState.keyHistory[vimState.keyHistory.length - 2]);
-    vimState.recordedState.surroundKeys.push('s');
-    vimState.recordedState.surroundKeyIndexStart = vimState.keyHistory.length;
-
-    vimState.surround = {
-      active: true,
-      target: undefined,
-      operator: operatorString,
-      replacement: undefined,
-      range: undefined,
-      previousMode: vimState.currentMode,
-    };
-
-    if (operatorString !== 'yank') {
-      await vimState.setCurrentMode(Mode.SurroundInputMode);
-    }
-
+async function StartSurroundMode(
+  vimState: VimState,
+  operatorString: 'change' | 'delete' | 'yank' | undefined = undefined,
+  keys: string[],
+  start: Position | undefined,
+  end: Position | undefined
+): Promise<VimState> {
+  // Only execute the action if the configuration is set
+  if (!configuration.surround || !operatorString || keys.length === 0) {
     return vimState;
   }
 
-  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    const hasSomeOperator = !!vimState.recordedState.operator;
-
-    return super.doesActionApply(vimState, keysPressed) && hasSomeOperator;
+  // Start to record the keys to store for playback of surround using dot
+  vimState.recordedState.surroundKeys.push(keys[0]);
+  if (operatorString === 'yank' && vimState.recordedState.operator) {
+    // include the motion keys after the operator
+    vimState.recordedState.surroundKeyIndexStart =
+      vimState.keyHistory.length - vimState.recordedState.actionKeys.length;
+  } else {
+    vimState.recordedState.surroundKeyIndexStart = vimState.keyHistory.length;
   }
 
-  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
-    const hasSomeOperator = !!vimState.recordedState.operator;
-
-    return super.doesActionApply(vimState, keysPressed) && hasSomeOperator;
+  let range: Range | undefined = undefined;
+  if (start && end) {
+    range = new Range(start, end);
   }
+
+  vimState.surround = {
+    active: true,
+    target: undefined,
+    operator: operatorString,
+    replacement: undefined,
+    range: range,
+    previousMode: vimState.currentMode,
+  };
+
+  if (operatorString === 'yank' && start) {
+    if (isVisualMode(vimState.surround.previousMode) && end) {
+      // Put the cursor at the beginning of the visual selection
+      vimState.cursorStopPosition = start;
+      vimState.cursorStartPosition = start;
+    } else {
+      vimState.cursorStopPosition = start;
+      vimState.cursorStartPosition = start;
+    }
+  }
+  await vimState.setCurrentMode(Mode.SurroundInputMode);
+
+  return vimState;
 }
 
-@RegisterAction
-class CommandSurroundModeStartVisual extends BaseCommand {
-  modes = [Mode.Visual, Mode.VisualLine];
-  keys = ['S'];
+class BaseSurroundCommand extends BaseCommand {
+  keys: string[] = [];
+  operatorString: 'change' | 'delete' | 'yank' | undefined = undefined;
   isCompleteAction = false;
   runsOnceForEveryCursor() {
     return false;
   }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
-    // Only execute the action if the configuration is set
-    if (!configuration.surround) {
+    if (!this.operatorString || this.keys.length === 0) {
       return vimState;
     }
+    return StartSurroundMode(vimState, this.operatorString, this.keys, undefined, undefined);
+  }
 
-    // Start to record the keys to store for playback of surround using dot
-    vimState.recordedState.surroundKeys.push('S');
-    vimState.recordedState.surroundKeyIndexStart = vimState.keyHistory.length;
+  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.doesActionApply(vimState, keysPressed);
+  }
 
+  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.couldActionApply(vimState, keysPressed);
+  }
+}
+
+@RegisterPluginAction('surround')
+class CommandChangeSurround extends BaseSurroundCommand {
+  modes = [Mode.Normal];
+  pluginActionDefaultKeys = ['c', 's'];
+  keys = ['<Plug>Csurround'];
+  operatorString: 'change' | 'delete' | 'yank' | undefined = 'change';
+}
+
+@RegisterPluginAction('surround')
+class CommandDeleteSurround extends BaseSurroundCommand {
+  modes = [Mode.Normal];
+  pluginActionDefaultKeys = ['d', 's'];
+  keys = ['<Plug>Dsurround'];
+  operatorString: 'change' | 'delete' | 'yank' | undefined = 'delete';
+}
+
+@RegisterPluginAction('surround')
+class CommandSurroundModeStartVisual extends BaseSurroundCommand {
+  modes = [Mode.Visual, Mode.VisualLine];
+  pluginActionDefaultKeys = ['S'];
+  keys = ['<Plug>VSurround'];
+  operatorString: 'change' | 'delete' | 'yank' | undefined = 'yank';
+
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
     let [start, end] = sorted(vimState.cursorStartPosition, vimState.cursorStopPosition);
     if (vimState.currentMode === Mode.VisualLine) {
       [start, end] = [start.getLineBegin(), end.getLineEnd()];
     }
+    return StartSurroundMode(vimState, 'yank', this.keys, start, end);
+  }
+}
 
-    vimState.surround = {
-      active: true,
-      target: undefined,
-      operator: 'yank',
-      replacement: undefined,
-      range: new Range(start, end),
-      previousMode: vimState.currentMode,
-    };
+@RegisterPluginAction('surround')
+class CommandSurroundModeStartLine extends BaseSurroundCommand {
+  modes = [Mode.Normal];
+  pluginActionDefaultKeys = ['y', 's', 's'];
+  keys = ['<Plug>Yssurround'];
 
-    await vimState.setCurrentMode(Mode.SurroundInputMode);
+  public async exec(position: Position, vimState: VimState): Promise<VimState> {
+    const start: Position = position.getLineBeginRespectingIndent();
+    const end: Position = position.getLineEnd().getLastWordEnd().getRight();
+    return StartSurroundMode(vimState, 'yank', this.keys, start, end);
+  }
+}
 
-    // Put the cursor at the beginning of the visual selection
-    vimState.cursorStopPosition = start;
-    vimState.cursorStartPosition = start;
+@RegisterPluginAction('surround')
+class SurroundModeStartOperator extends BaseOperator {
+  modes = [Mode.Normal];
+  pluginActionDefaultKeys = ['y', 's'];
+  keys = ['<Plug>Ysurround'];
+  isCompleteAction = false;
+  runsOnceForEveryCursor() {
+    return false;
+  }
 
-    return vimState;
+  public async run(vimState: VimState, start: Position, end: Position): Promise<VimState> {
+    return StartSurroundMode(vimState, 'yank', this.keys, start, end);
+  }
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.couldActionApply(vimState, keysPressed);
   }
 }
 
@@ -255,6 +263,14 @@ class CommandSurroundModeStartVisual extends BaseCommand {
 export class CommandSurroundAddToReplacement extends BaseCommand {
   modes = [Mode.SurroundInputMode];
   keys = ['<any>'];
+
+  public doesActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.doesActionApply(vimState, keysPressed);
+  }
+
+  public couldActionApply(vimState: VimState, keysPressed: string[]): boolean {
+    return configuration.surround && super.couldActionApply(vimState, keysPressed);
+  }
 
   public async exec(position: Position, vimState: VimState): Promise<VimState> {
     if (!vimState.surround) {

--- a/src/actions/plugins/surround.ts
+++ b/src/actions/plugins/surround.ts
@@ -125,7 +125,7 @@ class CommandSurroundAddTarget extends BaseCommand {
 
 @RegisterAction
 class CommandSurroundModeRepeat extends BaseMovement {
-  modes = [Mode.Normal];
+  modes = [Mode.OperatorPendingMode];
   keys = ['s'];
   isCompleteAction = false;
   runsOnceForEveryCursor() {

--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -20,7 +20,7 @@ import { ChangeOperator } from './operator';
 import { configuration } from './../configuration/configuration';
 
 export abstract class TextObjectMovement extends BaseMovement {
-  modes = [Mode.Normal, Mode.Visual, Mode.VisualBlock];
+  modes = [Mode.OperatorPendingMode, Mode.Visual, Mode.VisualBlock];
 
   public async execActionForOperator(position: Position, vimState: VimState): Promise<IMovement> {
     const res = await this.execAction(position, vimState);
@@ -262,7 +262,7 @@ export class SelectAnExpandingBlock extends ExpandingSelection {
 
 @RegisterAction
 export class SelectInnerWord extends TextObjectMovement {
-  modes = [Mode.Normal, Mode.Visual];
+  modes = [Mode.OperatorPendingMode, Mode.Visual];
   keys = ['i', 'w'];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {
@@ -303,7 +303,7 @@ export class SelectInnerWord extends TextObjectMovement {
 
 @RegisterAction
 export class SelectInnerBigWord extends TextObjectMovement {
-  modes = [Mode.Normal, Mode.Visual];
+  modes = [Mode.OperatorPendingMode, Mode.Visual];
   keys = ['i', 'W'];
 
   public async execAction(position: Position, vimState: VimState): Promise<IMovement> {

--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -687,7 +687,7 @@ class InsideIndentObjectBoth extends IndentObjectMatch {
 }
 
 abstract class SelectArgument extends TextObjectMovement {
-  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual];
+  modes = [Mode.OperatorPendingMode, Mode.Visual];
 
   private static openingDelimiterCharacters(): string[] {
     return configuration.argumentObjectOpeningDelimiters;

--- a/src/actions/textobject.ts
+++ b/src/actions/textobject.ts
@@ -687,7 +687,7 @@ class InsideIndentObjectBoth extends IndentObjectMatch {
 }
 
 abstract class SelectArgument extends TextObjectMovement {
-  modes = [Mode.Normal, Mode.Visual];
+  modes = [Mode.Normal, Mode.OperatorPendingMode, Mode.Visual];
 
   private static openingDelimiterCharacters(): string[] {
     return configuration.argumentObjectOpeningDelimiters;
@@ -930,13 +930,11 @@ abstract class SelectArgument extends TextObjectMovement {
 
 @RegisterAction
 export class SelectInnerArgument extends SelectArgument {
-  modes = [Mode.Normal, Mode.Visual];
   keys = ['i', 'a'];
 }
 
 @RegisterAction
 export class SelectAroundArgument extends SelectArgument {
-  modes = [Mode.Normal, Mode.Visual];
   keys = ['a', 'a'];
   selectAround = true;
 }

--- a/src/cmd_line/commands/put.ts
+++ b/src/cmd_line/commands/put.ts
@@ -4,6 +4,9 @@ import { configuration } from '../../configuration/configuration';
 
 import { Position } from '../../common/motion/position';
 import { PutCommand, IPutCommandOptions } from '../../actions/commands/put';
+import { Register } from '../../register/register';
+import { StatusBar } from '../../statusBar';
+import { VimError, ErrorCode } from '../../error';
 
 export interface IPutCommandArguments extends node.ICommandArgs {
   bang?: boolean;
@@ -31,8 +34,13 @@ export class PutExCommand extends node.CommandBase {
     return true;
   }
 
-  async doPut(vimState: VimState, position: Position) {
+  async doPut(vimState: VimState, position: Position): Promise<void> {
     const registerName = this.arguments.register || (configuration.useSystemClipboard ? '*' : '"');
+    if (!Register.isValidRegister(registerName)) {
+      StatusBar.displayError(vimState, VimError.fromCode(ErrorCode.TrailingCharacters));
+      return;
+    }
+
     vimState.recordedState.registerName = registerName;
 
     let options: IPutCommandOptions = {

--- a/src/cmd_line/commands/substitute.ts
+++ b/src/cmd_line/commands/substitute.ts
@@ -235,7 +235,7 @@ export class SubstituteCommand extends node.CommandBase {
     ];
 
     vimState.editor.revealRange(new vscode.Range(line, 0, line, 0));
-    vimState.editor.setDecorations(decoration.SearchHighlight, searchRanges);
+    vimState.editor.setDecorations(decoration.searchHighlight, searchRanges);
 
     const prompt = `Replace with ${replacement} (${validSelections.join('/')})?`;
     await vscode.window.showInputBox(

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -93,6 +93,46 @@ class Configuration implements IConfiguration {
 
     this.clearKeyBindingsMaps();
 
+    // Create or remove the default mappings for 'f', 'F', 't' and 'T' for sneak
+    const sneakMappings = ['<Plug>Sneak_f', '<Plug>Sneak_F', '<Plug>Sneak_t', '<Plug>Sneak_T'];
+    if (this.sneakReplacesF) {
+      for (const sneakMap of sneakMappings) {
+        this.defaultnormalModeKeyBindingsNonRecursive.push({
+          before: [sneakMap[sneakMap.length - 1]],
+          after: [sneakMap],
+        });
+        this.defaultvisualModeKeyBindingsNonRecursive.push({
+          before: [sneakMap[sneakMap.length - 1]],
+          after: [sneakMap],
+        });
+        this.defaultoperatorPendingModeKeyBindingsNonRecursive.push({
+          before: [sneakMap[sneakMap.length - 1]],
+          after: [sneakMap],
+        });
+      }
+    } else {
+      for (const sneakMap of sneakMappings) {
+        let idx = this.defaultnormalModeKeyBindingsNonRecursive.findIndex(
+          (r) => r.after && r.after[0] === sneakMap && r.after.length === 1
+        );
+        if (idx > -1) {
+          this.defaultnormalModeKeyBindingsNonRecursive.splice(idx, 1);
+        }
+        idx = this.defaultvisualModeKeyBindingsNonRecursive.findIndex(
+          (r) => r.after && r.after[0] === sneakMap && r.after.length === 1
+        );
+        if (idx > -1) {
+          this.defaultvisualModeKeyBindingsNonRecursive.splice(idx, 1);
+        }
+        idx = this.defaultoperatorPendingModeKeyBindingsNonRecursive.findIndex(
+          (r) => r.after && r.after[0] === sneakMap && r.after.length === 1
+        );
+        if (idx > -1) {
+          this.defaultoperatorPendingModeKeyBindingsNonRecursive.splice(idx, 1);
+        }
+      }
+    }
+
     const validatorResults = await configurationValidator.validate(configuration);
 
     // wrap keys

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -387,6 +387,16 @@ class Configuration implements IConfiguration {
   visualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   commandLineModeKeyBindings: IKeyRemapping[] = [];
   commandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultinsertModeKeyBindings: IKeyRemapping[] = [];
+  defaultinsertModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultnormalModeKeyBindings: IKeyRemapping[] = [];
+  defaultnormalModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultoperatorPendingModeKeyBindings: IKeyRemapping[] = [];
+  defaultoperatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultvisualModeKeyBindings: IKeyRemapping[] = [];
+  defaultvisualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultcommandLineModeKeyBindings: IKeyRemapping[] = [];
+  defaultcommandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
 
   insertModeKeyBindingsMap: Map<string, IKeyRemapping>;
   normalModeKeyBindingsMap: Map<string, IKeyRemapping>;

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -91,6 +91,8 @@ class Configuration implements IConfiguration {
 
     this.leader = Notation.NormalizeKey(this.leader, this.leaderDefault);
 
+    this.clearKeyBindingsMaps();
+
     const validatorResults = await configurationValidator.validate(configuration);
 
     // wrap keys
@@ -160,6 +162,15 @@ class Configuration implements IConfiguration {
     return this.cursorTypeMap[cursorStyle];
   }
 
+  clearKeyBindingsMaps() {
+    // Clear the KeyBindingsMaps so that the previous configuration maps don't leak to this one
+    this.normalModeKeyBindingsMap = new Map<string, IKeyRemapping>();
+    this.insertModeKeyBindingsMap = new Map<string, IKeyRemapping>();
+    this.visualModeKeyBindingsMap = new Map<string, IKeyRemapping>();
+    this.commandLineModeKeyBindingsMap = new Map<string, IKeyRemapping>();
+    this.operatorPendingModeKeyBindingsMap = new Map<string, IKeyRemapping>();
+  }
+
   handleKeys: IHandleKeys[] = [];
 
   useSystemClipboard = false;
@@ -219,6 +230,8 @@ class Configuration implements IConfiguration {
   };
 
   timeout = 1000;
+
+  maxmapdepth = 1000;
 
   showcmd = true;
 
@@ -368,19 +381,18 @@ class Configuration implements IConfiguration {
   insertModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   normalModeKeyBindings: IKeyRemapping[] = [];
   normalModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  operatorPendingModeKeyBindings: IKeyRemapping[] = [];
+  operatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   visualModeKeyBindings: IKeyRemapping[] = [];
   visualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   commandLineModeKeyBindings: IKeyRemapping[] = [];
   commandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
 
   insertModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  insertModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   normalModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  normalModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
+  operatorPendingModeKeyBindingsMap: Map<string, IKeyRemapping>;
   visualModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  visualModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   commandLineModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  commandLineModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
 
   private static unproxify(obj: Object): Object {
     let result = {};

--- a/src/configuration/decoration.ts
+++ b/src/configuration/decoration.ts
@@ -6,53 +6,89 @@ class DecorationImpl {
   private _searchHighlight: vscode.TextEditorDecorationType;
   private _easyMotionIncSearch: vscode.TextEditorDecorationType;
   private _easyMotionDimIncSearch: vscode.TextEditorDecorationType;
+  private _insertModeVirtualCharacter: vscode.TextEditorDecorationType;
+  private _operatorPendingModeCursor: vscode.TextEditorDecorationType;
+  private _operatorPendingModeCursorChar: vscode.TextEditorDecorationType;
 
-  public set Default(value: vscode.TextEditorDecorationType) {
+  public set default(value: vscode.TextEditorDecorationType) {
     if (this._default) {
       this._default.dispose();
     }
     this._default = value;
   }
 
-  public get Default() {
+  public get default() {
     return this._default;
   }
 
-  public set SearchHighlight(value: vscode.TextEditorDecorationType) {
+  public set searchHighlight(value: vscode.TextEditorDecorationType) {
     if (this._searchHighlight) {
       this._searchHighlight.dispose();
     }
     this._searchHighlight = value;
   }
 
-  public get SearchHighlight() {
+  public get searchHighlight() {
     return this._searchHighlight;
   }
 
-  public set EasyMotionIncSearch(value: vscode.TextEditorDecorationType) {
+  public set easyMotionIncSearch(value: vscode.TextEditorDecorationType) {
     if (this._easyMotionIncSearch) {
       this._easyMotionIncSearch.dispose();
     }
     this._easyMotionIncSearch = value;
   }
 
-  public set EasyMotionDimIncSearch(value: vscode.TextEditorDecorationType) {
+  public set easyMotionDimIncSearch(value: vscode.TextEditorDecorationType) {
     if (this._easyMotionDimIncSearch) {
       this._easyMotionDimIncSearch.dispose();
     }
     this._easyMotionDimIncSearch = value;
   }
 
-  public get EasyMotionIncSearch() {
+  public get easyMotionIncSearch() {
     return this._easyMotionIncSearch;
   }
 
-  public get EasyMotionDimIncSearch() {
+  public get easyMotionDimIncSearch() {
     return this._easyMotionDimIncSearch;
   }
 
+  public set insertModeVirtualCharacter(value: vscode.TextEditorDecorationType) {
+    if (this._insertModeVirtualCharacter) {
+      this._insertModeVirtualCharacter.dispose();
+    }
+    this._insertModeVirtualCharacter = value;
+  }
+
+  public get insertModeVirtualCharacter() {
+    return this._insertModeVirtualCharacter;
+  }
+
+  public set operatorPendingModeCursor(value: vscode.TextEditorDecorationType) {
+    if (this._operatorPendingModeCursor) {
+      this._operatorPendingModeCursor.dispose();
+    }
+    this._operatorPendingModeCursor = value;
+  }
+
+  public get operatorPendingModeCursor() {
+    return this._operatorPendingModeCursor;
+  }
+
+  public set operatorPendingModeCursorChar(value: vscode.TextEditorDecorationType) {
+    if (this._operatorPendingModeCursorChar) {
+      this._operatorPendingModeCursorChar.dispose();
+    }
+    this._operatorPendingModeCursorChar = value;
+  }
+
+  public get operatorPendingModeCursorChar() {
+    return this._operatorPendingModeCursorChar;
+  }
+
   public load(configuration: IConfiguration) {
-    this.Default = vscode.window.createTextEditorDecorationType({
+    this.default = vscode.window.createTextEditorDecorationType({
       backgroundColor: new vscode.ThemeColor('editorCursor.foreground'),
       borderColor: new vscode.ThemeColor('editorCursor.foreground'),
       dark: {
@@ -70,19 +106,68 @@ class DecorationImpl {
       ? configuration.searchHighlightColor
       : new vscode.ThemeColor('editor.findMatchHighlightBackground');
 
-    this.SearchHighlight = vscode.window.createTextEditorDecorationType({
+    this.searchHighlight = vscode.window.createTextEditorDecorationType({
       backgroundColor: searchHighlightColor,
       color: configuration.searchHighlightTextColor,
       overviewRulerColor: new vscode.ThemeColor('editorOverviewRuler.findMatchForeground'),
     });
 
-    this.EasyMotionIncSearch = vscode.window.createTextEditorDecorationType({
+    this.easyMotionIncSearch = vscode.window.createTextEditorDecorationType({
       color: configuration.easymotionIncSearchForegroundColor,
       fontWeight: configuration.easymotionMarkerFontWeight,
     });
 
-    this.EasyMotionDimIncSearch = vscode.window.createTextEditorDecorationType({
+    this.easyMotionDimIncSearch = vscode.window.createTextEditorDecorationType({
       color: configuration.easymotionDimColor,
+    });
+
+    this.insertModeVirtualCharacter = vscode.window.createTextEditorDecorationType({
+      color: 'transparent', // no color to hide the existing character
+      before: {
+        color: 'currentColor',
+        backgroundColor: new vscode.ThemeColor('editor.background'),
+        borderColor: new vscode.ThemeColor('editor.background'),
+        margin: '0 -1ch 0 0',
+        height: '100%',
+      },
+    });
+
+    // This creates the half block cursor when on operator pending mode
+    this.operatorPendingModeCursor = vscode.window.createTextEditorDecorationType({
+      before: {
+        // no color to hide the existing character. We only need the character here to make
+        // the width be the same as the existing character.
+        color: 'transparent',
+        // The '-1ch' right margin is so that it displays on top of the existing character. The amount
+        // here doesn't really matter, it could be '-1px' it just needs to be negative so that the left
+        // of this 'before' element coincides with the left of the existing character.
+        margin: `0 -1ch 0 0;
+        position: absolute;
+        bottom: 0;
+        line-height: 0;`,
+        height: '50%',
+        backgroundColor: new vscode.ThemeColor('editorCursor.foreground'),
+      },
+    });
+
+    // This puts a character on top of the half block cursor and on top of the existing character
+    // to create the mix-blend 'magic'
+    this.operatorPendingModeCursorChar = vscode.window.createTextEditorDecorationType({
+      // We make the existing character 'black' -> rgb(0,0,0), because when using the mix-blend-mode
+      // with 'exclusion' it subtracts the darker color from the lightest color which means we will
+      // subtract zero from our 'currentcolor' leaving us with 'currentcolor' on the part above the
+      // background of the half cursor.
+      color: 'black',
+      before: {
+        color: 'currentcolor',
+        // The '-1ch' right margin is so that it displays on top of the existing character. The amount
+        // here doesn't really matter, it could be '-1px' it just needs to be negative so that the left
+        // of this 'before' element coincides with the left of the existing character.
+        margin: `0 -1ch 0 0;
+        position: absolute;
+        mix-blend-mode: exclusion;`,
+        height: '100%',
+      },
     });
   }
 }

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -349,6 +349,16 @@ export interface IConfiguration {
   visualModeKeyBindingsNonRecursive: IKeyRemapping[];
   commandLineModeKeyBindings: IKeyRemapping[];
   commandLineModeKeyBindingsNonRecursive: IKeyRemapping[];
+  defaultinsertModeKeyBindings: IKeyRemapping[];
+  defaultinsertModeKeyBindingsNonRecursive: IKeyRemapping[];
+  defaultnormalModeKeyBindings: IKeyRemapping[];
+  defaultnormalModeKeyBindingsNonRecursive: IKeyRemapping[];
+  defaultoperatorPendingModeKeyBindings: IKeyRemapping[];
+  defaultoperatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[];
+  defaultvisualModeKeyBindings: IKeyRemapping[];
+  defaultvisualModeKeyBindingsNonRecursive: IKeyRemapping[];
+  defaultcommandLineModeKeyBindings: IKeyRemapping[];
+  defaultcommandLineModeKeyBindingsNonRecursive: IKeyRemapping[];
 
   /**
    * These are constructed by the RemappingValidator

--- a/src/configuration/iconfiguration.ts
+++ b/src/configuration/iconfiguration.ts
@@ -14,6 +14,8 @@ export interface IModeSpecificStrings<T> {
 export interface IKeyRemapping {
   before: string[];
   after?: string[];
+  // 'recursive' is calculated when validating, according to the config that stored the remapping
+  recursive?: boolean;
   commands?: ({ command: string; args: any[] } | string)[];
   source?: 'vscode' | 'vimrc';
 }
@@ -185,6 +187,14 @@ export interface IConfiguration {
   timeout: number;
 
   /**
+   * Maximum number of times a mapping is done without resulting in a
+   * character to be used. This normally catches endless mappings, like
+   * ":map x y" with ":map y x". It still does not catch ":map g wg",
+   * because the 'w' is used before the next mapping is done.
+   */
+  maxmapdepth: number;
+
+  /**
    * Display partial commands on status bar?
    */
   showcmd: boolean;
@@ -333,6 +343,8 @@ export interface IConfiguration {
   insertModeKeyBindingsNonRecursive: IKeyRemapping[];
   normalModeKeyBindings: IKeyRemapping[];
   normalModeKeyBindingsNonRecursive: IKeyRemapping[];
+  operatorPendingModeKeyBindings: IKeyRemapping[];
+  operatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[];
   visualModeKeyBindings: IKeyRemapping[];
   visualModeKeyBindingsNonRecursive: IKeyRemapping[];
   commandLineModeKeyBindings: IKeyRemapping[];
@@ -342,13 +354,10 @@ export interface IConfiguration {
    * These are constructed by the RemappingValidator
    */
   insertModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  insertModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   normalModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  normalModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
+  operatorPendingModeKeyBindingsMap: Map<string, IKeyRemapping>;
   visualModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  visualModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   commandLineModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  commandLineModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
 
   /**
    * Comma-separated list of motion keys that should wrap to next/previous line.

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -51,10 +51,12 @@ export class Notation {
       return key;
     }
 
+    let originalKey: string = key.slice(0);
     key = key.toLocaleLowerCase();
 
     if (!this.isSurroundedByAngleBrackets(key)) {
       key = `<${key}>`;
+      originalKey = `<${originalKey}`;
     }
 
     if (key === '<leader>') {
@@ -69,7 +71,11 @@ export class Notation {
       key = key.replace(regex, standardNotation);
     }
 
-    return key;
+    if (originalKey.toLocaleLowerCase() === key) {
+      return originalKey;
+    } else {
+      return key;
+    }
   }
 
   /**

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -3,14 +3,14 @@ import { configuration } from './configuration';
 export class Notation {
   // Mapping from a regex to the normalized string that it should be converted to.
   private static readonly _notationMap: Array<[RegExp, string]> = [
-    [/<ctrl\+|<c\-/gi, '<C-'],
-    [/<cmd\+|<d\-/gi, '<D-'],
-    [/<escape>|<esc>/gi, '<Esc>'],
-    [/<backspace>|<bs>/gi, '<BS>'],
-    [/<delete>|<del>/gi, '<Del>'],
-    [/<home>/gi, '<Home>'],
-    [/<end>/gi, '<End>'],
-    [/<insert>/gi, '<Insert>'],
+    [/ctrl\+|c\-/gi, 'C-'],
+    [/cmd\+|d\-/gi, 'D-'],
+    [/escape|esc/gi, 'Esc'],
+    [/backspace|bs/gi, 'BS'],
+    [/delete|del/gi, 'Del'],
+    [/home/gi, 'Home'],
+    [/end/gi, 'End'],
+    [/insert/gi, 'Insert'],
     [/<space>/gi, ' '],
     [/<cr>|<enter>/gi, '\n'],
   ];
@@ -51,12 +51,15 @@ export class Notation {
       return key;
     }
 
-    let originalKey: string = key.slice(0);
+    if (/^<Plug>.+/gi.test(key)) {
+      // Plugin key. Return it as is
+      return key;
+    }
+
     key = key.toLocaleLowerCase();
 
     if (!this.isSurroundedByAngleBrackets(key)) {
       key = `<${key}>`;
-      originalKey = `<${originalKey}>`;
     }
 
     if (key === '<leader>') {
@@ -71,11 +74,7 @@ export class Notation {
       key = key.replace(regex, standardNotation);
     }
 
-    if (originalKey.toLocaleLowerCase() === key) {
-      return originalKey;
-    } else {
-      return key;
-    }
+    return key;
   }
 
   /**

--- a/src/configuration/notation.ts
+++ b/src/configuration/notation.ts
@@ -3,14 +3,14 @@ import { configuration } from './configuration';
 export class Notation {
   // Mapping from a regex to the normalized string that it should be converted to.
   private static readonly _notationMap: Array<[RegExp, string]> = [
-    [/ctrl\+|c\-/gi, 'C-'],
-    [/cmd\+|d\-/gi, 'D-'],
-    [/escape|esc/gi, 'Esc'],
-    [/backspace|bs/gi, 'BS'],
-    [/delete|del/gi, 'Del'],
-    [/home/gi, 'Home'],
-    [/end/gi, 'End'],
-    [/insert/gi, 'Insert'],
+    [/<ctrl\+|<c\-/gi, '<C-'],
+    [/<cmd\+|<d\-/gi, '<D-'],
+    [/<escape>|<esc>/gi, '<Esc>'],
+    [/<backspace>|<bs>/gi, '<BS>'],
+    [/<delete>|<del>/gi, '<Del>'],
+    [/<home>/gi, '<Home>'],
+    [/<end>/gi, '<End>'],
+    [/<insert>/gi, '<Insert>'],
     [/<space>/gi, ' '],
     [/<cr>|<enter>/gi, '\n'],
   ];
@@ -56,7 +56,7 @@ export class Notation {
 
     if (!this.isSurroundedByAngleBrackets(key)) {
       key = `<${key}>`;
-      originalKey = `<${originalKey}`;
+      originalKey = `<${originalKey}>`;
     }
 
     if (key === '<leader>') {

--- a/src/configuration/remapper.ts
+++ b/src/configuration/remapper.ts
@@ -7,6 +7,8 @@ import { VimState } from './../state/vimState';
 import { commandLine } from '../cmd_line/commandLine';
 import { configuration } from '../configuration/configuration';
 import { StatusBar } from '../statusBar';
+import { VimError, ErrorCode, ForceStopRemappingError } from '../error';
+import { SpecialKeys } from '../util/specialKeys';
 
 interface IRemapper {
   /**
@@ -25,14 +27,11 @@ export class Remappers implements IRemapper {
 
   constructor() {
     this.remappers = [
-      new InsertModeRemapper(true),
-      new NormalModeRemapper(true),
-      new VisualModeRemapper(true),
-      new CommandLineModeRemapper(true),
-      new InsertModeRemapper(false),
-      new NormalModeRemapper(false),
-      new VisualModeRemapper(false),
-      new CommandLineModeRemapper(false),
+      new InsertModeRemapper(),
+      new NormalModeRemapper(),
+      new VisualModeRemapper(),
+      new CommandLineModeRemapper(),
+      new OperatorPendingModeRemapper(),
     ];
   }
 
@@ -46,6 +45,7 @@ export class Remappers implements IRemapper {
     vimState: VimState
   ): Promise<boolean> {
     let handled = false;
+
     for (let remapper of this.remappers) {
       handled = handled || (await remapper.sendKey(keys, modeHandler, vimState));
     }
@@ -56,17 +56,49 @@ export class Remappers implements IRemapper {
 export class Remapper implements IRemapper {
   private readonly _configKey: string;
   private readonly _remappedModes: Mode[];
-  private readonly _recursive: boolean;
   private readonly _logger = Logger.get('Remapper');
 
+  /**
+   * Checks if the current commandList is a potential remap.
+   */
   private _isPotentialRemap = false;
+
+  /**
+   * If the commandList has a remap but there is still another potential remap we
+   * call it an Ambiguous Remap and we store it here. If later we need to handle it
+   * we don't need to go looking for it.
+   */
+  private _hasAmbiguousRemap: IKeyRemapping | undefined;
+
+  /**
+   * If the commandList is a potential remap but has no ambiguous remap
+   * yet, we say that it has a Potential Remap.
+   *
+   * This is to distinguish the commands with ambiguous remaps and the
+   * ones without.
+   *
+   * Example 1: if 'aaaa' is mapped and so is 'aa', when the user has pressed
+   * 'aaa' we say it has an Ambiguous Remap which is 'aa', because if the
+   * user presses other key than 'a' next or waits for the timeout to finish
+   * we need to now that there was a remap to run so we first run the 'aa'
+   * remap and then handle the remaining keys.
+   *
+   * Example 2: if only 'aaaa' is mapped, when the user has pressed 'aaa'
+   * we say it has a Potential Remap, because if the user presses other key
+   * than 'a' next or waits for the timeout to finish we need to now that
+   * there was a potential remap that never came or was broken, so we can
+   * resend the keys again without allowing for a potential remap on the first
+   * key, which means we won't get to the same state because the first key
+   * will be handled as an action (in this case a 'CommandInsertAfterCursor')
+   */
+  private _hasPotentialRemap = false;
+
   get isPotentialRemap(): boolean {
     return this._isPotentialRemap;
   }
 
-  constructor(configKey: string, remappedModes: Mode[], recursive: boolean) {
+  constructor(configKey: string, remappedModes: Mode[]) {
     this._configKey = configKey;
-    this._recursive = recursive;
     this._remappedModes = remappedModes;
   }
 
@@ -76,85 +108,391 @@ export class Remapper implements IRemapper {
     vimState: VimState
   ): Promise<boolean> {
     this._isPotentialRemap = false;
+    const allowPotentialRemapOnFirstKey = vimState.recordedState.allowPotentialRemapOnFirstKey;
+    let remainingKeys: string[] = [];
 
-    if (!this._remappedModes.includes(vimState.currentMode)) {
+    /**
+     * Means that the timeout finished so we now can't allow the keys to be buffered again
+     * because the user already waited for timeout.
+     */
+    let allowBufferingKeys = true;
+
+    if (!this._remappedModes.includes(vimState.currentModeIncludingPseudoModes)) {
       return false;
     }
 
     const userDefinedRemappings = configuration[this._configKey] as Map<string, IKeyRemapping>;
+
+    if (keys[keys.length - 1] === SpecialKeys.TimeoutFinished) {
+      // Timeout finished. Don't let an ambiguous or potential remap start another timeout again
+      keys = keys.slice(0, keys.length - 1);
+      allowBufferingKeys = false;
+    }
+
+    if (keys.length === 0) {
+      return true;
+    }
 
     this._logger.debug(
       `trying to find matching remap. keys=${keys}. mode=${
         Mode[vimState.currentMode]
       }. keybindings=${this._configKey}.`
     );
+
     let remapping: IKeyRemapping | undefined = this.findMatchingRemap(
       userDefinedRemappings,
       keys,
       vimState.currentMode
     );
 
-    if (remapping) {
-      this._logger.debug(
-        `${this._configKey}. match found. before=${remapping.before}. after=${remapping.after}. command=${remapping.commands}.`
-      );
+    // Check to see if a remapping could potentially be applied when more keys are received
+    let isPotentialRemap = Remapper.hasPotentialRemap(keys, userDefinedRemappings);
 
-      if (!this._recursive) {
-        vimState.isCurrentlyPerformingRemapping = true;
+    this._isPotentialRemap =
+      isPotentialRemap && allowBufferingKeys && allowPotentialRemapOnFirstKey;
+
+    /**
+     * Handle a broken potential or ambiguous remap
+     * 1. If this Remapper doesn't have a remapping AND
+     * 2. (It previously had an AmbiguousRemap OR a PotentialRemap) AND
+     * 3. (It doesn't have a potential remap anymore OR timeout finished) AND
+     * 4. keys length is more than 1
+     *
+     * Points 1-3: If we no longer have a remapping but previously had one or a potential one
+     * and there is no longer potential remappings because of another pressed key or because the
+     * timeout has passed we need to handle those situations by resending the keys or handling the
+     * ambiguous remap and resending any remaining keys.
+     * Point 4: if there is only one key there is no point in resending it without allowing remaps
+     * on first key, we can let the remapper go to the end because since either there was no potential
+     * remap anymore or the timeout finished so this means that the next two checks (the 'Buffer keys
+     * and create timeout' and 'Handle remapping and remaining keys') will never be hit, so it reaches
+     * the end without doing anything which means that this key will be handled as an action as intended.
+     */
+    if (
+      !remapping &&
+      (this._hasAmbiguousRemap || this._hasPotentialRemap) &&
+      (!isPotentialRemap || !allowBufferingKeys) &&
+      keys.length > 1
+    ) {
+      if (this._hasAmbiguousRemap) {
+        remapping = this._hasAmbiguousRemap;
+        isPotentialRemap = false;
+        this._isPotentialRemap = false;
+
+        // Use the commandList to get the remaining keys so that it includes any existing
+        // '<TimeoutFinished>' key
+        remainingKeys = vimState.recordedState.commandList.slice(remapping.before.length);
+        this._hasAmbiguousRemap = undefined;
+      }
+      if (!remapping) {
+        // if there is still no remapping, handle all the keys without allowing
+        // a potential remap on the first key so that we don't repeat everything
+        // again, but still allow for other ambiguous remaps after the first key.
+        //
+        // Example: if 'iiii' is mapped in normal and 'ii' is mapped in insert mode,
+        // and the user presses 'iiia' in normal mode or presses 'iii' and waits
+        // for the timeout to finish, we want the first 'i' to be handled without
+        // allowing potential remaps, which means it will go into insert mode,
+        // but then the next 'ii' should be remapped in insert mode and after the
+        // remap the 'a' should be handled.
+        if (!allowBufferingKeys) {
+          // Timeout finished and there is no remapping, so handle the buffered
+          // keys but resend the '<TimeoutFinished>' key as well so we don't wait
+          // for the timeout again but can still handle potential remaps.
+          //
+          // Example 1: if 'ccc' is mapped in normal mode and user presses 'cc' and
+          // waits for the timeout to finish, this will resend the 'cc<TimeoutFinished>'
+          // keys without allowing a potential remap on first key, which makes the
+          // first 'c' be handled as a 'ChangeOperator' and the second 'c' which has
+          // potential remaps (the 'ccc' remap) is buffered and the timeout started
+          // but then the '<TimeoutFinished>' key comes straight away that clears the
+          // timeout without waiting again, and makes the second 'c' be handled normally
+          // as another 'ChangeOperator'.
+          //
+          // Example 2: if 'iiii' is mapped in normal and 'ii' is mapped in insert
+          // mode, and the user presses 'iii' in normal mode and waits for the timeout
+          // to finish, this will resend the 'iii<TimeoutFinished>' keys without allowing
+          // a potential remap on first key, which makes the first 'i' be handled as
+          // an 'CommandInsertAtCursor' and goes to insert mode, next the second 'i'
+          // is buffered, then the third 'i' finds the insert mode remapping of 'ii'
+          // and handles that remap, after the remapping being handled the '<TimeoutFinished>'
+          // key comes that clears the timeout and since the commandList will be empty
+          // we return true as we finished handling this sequence of keys.
+
+          keys.push(SpecialKeys.TimeoutFinished); // include the '<TimeoutFinished>' key
+
+          this._logger.debug(
+            `${this._configKey}. timeout finished, handling timed out buffer keys without allowing a new timeout.`
+          );
+        }
+        this._logger.debug(
+          `${this._configKey}. potential remap broken. resending keys without allowing a potential remap on first key. keys=${keys}`
+        );
+        this._hasPotentialRemap = false;
+        vimState.recordedState.allowPotentialRemapOnFirstKey = false;
+        vimState.recordedState.resetCommandList();
+
+        if (vimState.wasPerformingRemapThatFinishedWaitingForTimeout) {
+          // Some keys that broke the possible remap were typed by the user so handle them seperatly
+          const lastRemapLength = vimState.wasPerformingRemapThatFinishedWaitingForTimeout.after!
+            .length;
+          const keysPressedByUser = keys.slice(lastRemapLength);
+          keys = keys.slice(0, lastRemapLength);
+
+          try {
+            vimState.isCurrentlyPerformingRecursiveRemapping = true;
+            await modeHandler.handleMultipleKeyEvents(keys);
+          } catch (e) {
+            if (e instanceof ForceStopRemappingError) {
+              this._logger.debug(
+                `${this._configKey}. Stopped the remapping in the middle, ignoring the rest. Reason: ${e.message}`
+              );
+            }
+          } finally {
+            vimState.isCurrentlyPerformingRecursiveRemapping = false;
+            vimState.wasPerformingRemapThatFinishedWaitingForTimeout = false;
+            await modeHandler.handleMultipleKeyEvents(keysPressedByUser);
+          }
+        } else {
+          await modeHandler.handleMultipleKeyEvents(keys);
+        }
+        return true;
+      }
+    }
+
+    /**
+     * Buffer keys and create timeout
+     * 1. If the current keys have a potential remap AND
+     * 2. The timeout hasn't finished yet so we allow buffering keys AND
+     * 3. We allow potential remap on first key (check the note on RecordedState. TLDR: this will only
+     * be false for one key, the first one, when we resend keys that had a potential remap but no longer
+     * have it or the timeout finished)
+     *
+     * Points 1-3: If the current keys still have a potential remap and the timeout hasn't finished yet
+     * and we are not preventing a potential remap on the first key then we need to buffer this keys
+     * and wait for another key or the timeout to finish.
+     */
+    if (isPotentialRemap && allowBufferingKeys && allowPotentialRemapOnFirstKey) {
+      if (remapping) {
+        // There are other potential remaps (ambiguous remaps), wait for other key or for the timeout
+        // to finish. Also store this current ambiguous remap on '_hasAmbiguousRemap' so that if later
+        // this ambiguous remap is broken or the user waits for timeout we don't need to go looking for
+        // it again.
+        this._hasAmbiguousRemap = remapping;
+
+        this._logger.debug(
+          `${this._configKey}. ambiguous match found. before=${remapping.before}. after=${remapping.after}. command=${remapping.commands}. waiting for other key or timeout to finish.`
+        );
+      } else {
+        this._hasPotentialRemap = true;
+        this._logger.debug(
+          `${this._configKey}. potential remap found. waiting for other key or timeout to finish.`
+        );
       }
 
+      // Store BufferedKeys
+      vimState.recordedState.bufferedKeys = [...keys];
+
+      // Create Timeout
+      vimState.recordedState.bufferedKeysTimeoutObj = setTimeout(() => {
+        modeHandler.handleKeyEvent(SpecialKeys.TimeoutFinished);
+      }, configuration.timeout);
+      return true;
+    }
+
+    /**
+     * Handle Remapping and any remaining keys
+     * If we get here with a remapping that means we need to handle it.
+     */
+    if (remapping) {
+      if (!allowBufferingKeys) {
+        // If the user already waited for the timeout to finish, prevent the
+        // remapping from waiting for the timeout again by making a clone of
+        // remapping and change 'after' to send the '<TimeoutFinished>' key at
+        // the end.
+        let newRemapping = { ...remapping };
+        newRemapping.after = remapping.after?.slice(0);
+        newRemapping.after?.push(SpecialKeys.TimeoutFinished);
+        remapping = newRemapping;
+      }
+
+      this._hasAmbiguousRemap = undefined;
+      this._hasPotentialRemap = false;
+
+      let skipFirstCharacter = false;
+
+      // If we were performing a remapping already, it means this remapping has a parent remapping
+      const hasParentRemapping = vimState.isCurrentlyPerformingRemapping;
+      if (!hasParentRemapping) {
+        vimState.mapDepth = 0;
+      }
+
+      if (!remapping.recursive) {
+        vimState.isCurrentlyPerformingNonRecursiveRemapping = true;
+      } else {
+        vimState.isCurrentlyPerformingRecursiveRemapping = true;
+
+        // As per the Vim documentation: (:help recursive)
+        // If the {rhs} starts with {lhs}, the first character is not mapped
+        // again (this is Vi compatible).
+        // For example:
+        // map ab abcd
+        // will execute the "a" command and insert "bcd" in the text. The "ab"
+        // in the {rhs} will not be mapped again.
+        if (remapping.after?.join('').startsWith(remapping.before.join(''))) {
+          skipFirstCharacter = true;
+        }
+      }
+
+      // Increase mapDepth
+      vimState.mapDepth++;
+
+      this._logger.debug(
+        `${this._configKey}. match found. before=${remapping.before}. after=${remapping.after}. command=${remapping.commands}. remainingKeys=${remainingKeys}. mapDepth=${vimState.mapDepth}.`
+      );
+
+      let remapFailed = false;
+
       try {
-        await this.handleRemapping(remapping, vimState, modeHandler);
+        // Check maxMapDepth
+        if (vimState.mapDepth >= configuration.maxmapdepth) {
+          const vimError = VimError.fromCode(ErrorCode.RecursiveMapping);
+          StatusBar.displayError(vimState, vimError);
+          throw ForceStopRemappingError.fromVimError(vimError);
+        }
+
+        // Hacky code incoming!!! If someone has a better way to do this please change it
+        if (vimState.mapDepth % 10 === 0) {
+          // Allow the user to press <C-c> or <Esc> key when inside an infinite looping remap.
+          // When inside an infinite looping recursive mapping it would block the editor until it reached
+          // the maxmapdepth. This 0ms wait allows the extension to handle any key typed by the user which
+          // means it allows the user to press <C-c> or <Esc> to force stop the looping remap.
+          // This shouldn't impact the normal use case because we're only running this every 10 nested
+          // remaps. Also when the logs are set to Error only, a looping recursive remap takes around 1.5s
+          // to reach 1000 mapDepth and give back control to the user, but when logs are set to debug it
+          // can take as long as 7 seconds.
+          const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+          await wait(0);
+        }
+
+        vimState.remapUsedACharacter = false;
+
+        await this.handleRemapping(remapping, vimState, modeHandler, skipFirstCharacter);
+      } catch (e) {
+        if (e instanceof ForceStopRemappingError) {
+          // If a motion fails or a VimError happens during any kind of remapping or if the user presses the
+          // force stop remapping key (<C-c> or <Esc>) during a recursive remapping it should stop handling
+          // the remap and all its parent remaps if we are on a chain of recursive remaps.
+          // (Vim documentation :help map-error)
+          remapFailed = true;
+
+          // keep throwing until we reach the first parent
+          if (hasParentRemapping) {
+            throw e;
+          }
+
+          this._logger.debug(
+            `${this._configKey}. Stopped the remapping in the middle, ignoring the rest. Reason: ${e.message}`
+          );
+        } else {
+          // If some other error happens during the remapping handling it should stop the remap and rethrow
+          this._logger.debug(
+            `${this._configKey}. error found in the middle of remapping, ignoring the rest of the remap. error: ${e}`
+          );
+          throw e;
+        }
       } finally {
-        vimState.isCurrentlyPerformingRemapping = false;
+        // Check if we are still inside a recursive remap
+        if (!hasParentRemapping && vimState.isCurrentlyPerformingRecursiveRemapping) {
+          // no more recursive remappings being handled
+          if (vimState.recordedState.bufferedKeysTimeoutObj !== undefined) {
+            // In order to be able to receive other keys and at the same time wait for timeout, we need
+            // to create a timeout and return from the remapper so that modeHandler can be free to receive
+            // more keys. This means that if we are inside a recursive remapping, when we return on the
+            // last key of that remapping it will think that it is finished and set the currently
+            // performing recursive remapping flag to false, which would result in the current bufferedKeys
+            // not knowing they had a parent remapping. So we store that remapping here.
+            vimState.wasPerformingRemapThatFinishedWaitingForTimeout = { ...remapping };
+          }
+          vimState.isCurrentlyPerformingRecursiveRemapping = false;
+        }
+
+        if (!hasParentRemapping) {
+          // Last remapping finished handling. Set undo step.
+          vimState.historyTracker.finishCurrentStep();
+        }
+
+        // NonRecursive remappings can't have nested remaps so after a finished remap we always set this to
+        // false, because either we were performing a non recursive remap and now we finish or we weren't
+        // performing a non recursive remapping and this was false anyway.
+        vimState.isCurrentlyPerformingNonRecursiveRemapping = false;
+
+        // if there were other remaining keys on the buffered keys that weren't part of the remapping
+        // handle them now, except if the remap failed and the remaining keys weren't typed by the user.
+        // (we know that if this remapping has a parent remapping then the remaining keys weren't typed
+        // by the user, but instead were sent by the parent remapping handler)
+        if (remainingKeys.length > 0 && !(remapFailed && hasParentRemapping)) {
+          if (vimState.wasPerformingRemapThatFinishedWaitingForTimeout) {
+            // If there was a performing remap that finished waiting for timeout then only the remaining keys
+            // that are not part of that remap were typed by the user.
+            let specialKey: string | undefined = '';
+            if (remainingKeys[remainingKeys.length - 1] === SpecialKeys.TimeoutFinished) {
+              specialKey = remainingKeys.pop();
+            }
+            const lastRemap = vimState.wasPerformingRemapThatFinishedWaitingForTimeout.after!;
+            const lastRemapWithoutAmbiguousRemap = lastRemap.slice(remapping.before.length);
+            const keysPressedByUser = remainingKeys.slice(lastRemapWithoutAmbiguousRemap.length);
+            remainingKeys = remainingKeys.slice(0, remainingKeys.length - keysPressedByUser.length);
+            if (specialKey) {
+              remainingKeys.push(specialKey);
+              if (keysPressedByUser.length !== 0) {
+                keysPressedByUser.push(specialKey);
+              }
+            }
+            try {
+              vimState.isCurrentlyPerformingRecursiveRemapping = true;
+              await modeHandler.handleMultipleKeyEvents(remainingKeys);
+            } catch (e) {
+              this._logger.debug(
+                `${this._configKey}. Stopped the remapping in the middle, ignoring the rest. Reason: ${e.message}`
+              );
+            } finally {
+              vimState.isCurrentlyPerformingRecursiveRemapping = false;
+              vimState.wasPerformingRemapThatFinishedWaitingForTimeout = false;
+              if (keysPressedByUser.length > 0) {
+                await modeHandler.handleMultipleKeyEvents(keysPressedByUser);
+              }
+            }
+          } else {
+            await modeHandler.handleMultipleKeyEvents(remainingKeys);
+          }
+        }
       }
 
       return true;
     }
 
-    // Check to see if a remapping could potentially be applied when more keys are received
-    const keysAsString = keys.join('');
-    for (let remap of userDefinedRemappings.keys()) {
-      if (remap.startsWith(keysAsString)) {
-        this._isPotentialRemap = true;
-        break;
-      }
-    }
-
+    this._hasPotentialRemap = false;
+    this._hasAmbiguousRemap = undefined;
     return false;
   }
 
   private async handleRemapping(
     remapping: IKeyRemapping,
     vimState: VimState,
-    modeHandler: ModeHandler
+    modeHandler: ModeHandler,
+    skipFirstCharacter: boolean
   ) {
-    const numCharsToRemove = remapping.before.length - 1;
-    // Revert previously inserted characters
-    // (e.g. jj remapped to esc, we have to revert the inserted "jj")
-    if (vimState.currentMode === Mode.Insert) {
-      // Revert every single inserted character.
-      // We subtract 1 because we haven't actually applied the last key.
-
-      // Make sure the resulting selection changed events are ignored
-      vimState.selectionsChanged.ignoreIntermediateSelections = true;
-      await vimState.historyTracker.undoAndRemoveChanges(
-        Math.max(0, numCharsToRemove * vimState.cursors.length)
-      );
-      vimState.cursors = vimState.cursors.map((c) =>
-        c.withNewStop(c.stop.getLeft(numCharsToRemove))
-      );
-      vimState.selectionsChanged.ignoreIntermediateSelections = false;
-    }
-    // We need to remove the keys that were remapped into different keys from the state.
-    vimState.recordedState.actionKeys = vimState.recordedState.actionKeys.slice(
-      0,
-      -numCharsToRemove
-    );
-    vimState.keyHistory = vimState.keyHistory.slice(0, -numCharsToRemove);
-
+    vimState.recordedState.resetCommandList();
     if (remapping.after) {
-      await modeHandler.handleMultipleKeyEvents(remapping.after);
+      if (skipFirstCharacter) {
+        vimState.isCurrentlyPerformingNonRecursiveRemapping = true;
+        await modeHandler.handleKeyEvent(remapping.after[0]);
+        vimState.isCurrentlyPerformingNonRecursiveRemapping = false;
+        await modeHandler.handleMultipleKeyEvents(remapping.after.slice(1));
+      } else {
+        await modeHandler.handleMultipleKeyEvents(remapping.after);
+      }
     }
 
     if (remapping.commands) {
@@ -201,7 +539,7 @@ export class Remapper implements IRemapper {
     }
 
     const range = Remapper.getRemappedKeysLengthRange(userDefinedRemappings);
-    const startingSliceLength = Math.max(range[1], inputtedKeys.length);
+    const startingSliceLength = inputtedKeys.length;
     for (let sliceLength = startingSliceLength; sliceLength >= range[0]; sliceLength--) {
       const keySlice = inputtedKeys.slice(-sliceLength).join('');
 
@@ -240,43 +578,66 @@ export class Remapper implements IRemapper {
     if (remappings.size === 0) {
       return [0, 0];
     }
-    const keyLengths = Array.from(remappings.keys()).map((k) => k.length);
+    const keyLengths = Array.from(remappings.values()).map((remap) => remap.before.length);
     return [Math.min(...keyLengths), Math.max(...keyLengths)];
+  }
+
+  /**
+   * Given list of keys and list of remappings, returns true if the keys are a potential remap
+   * @param keys the list of keys to be checked for potential remaps
+   * @param remappings The remappings Map
+   * @param countRemapAsPotential If the current keys are themselves a remap should they be considered a potential remap as well?
+   */
+  protected static hasPotentialRemap(
+    keys: string[],
+    remappings: Map<string, IKeyRemapping>,
+    countRemapAsPotential: boolean = false
+  ): boolean {
+    const keysAsString = keys.join('');
+    if (keysAsString !== '') {
+      for (let remap of remappings.keys()) {
+        if (remap.startsWith(keysAsString) && (remap !== keysAsString || countRemapAsPotential)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }
 
-function keyBindingsConfigKey(mode: string, recursive: boolean): string {
-  return `${mode}ModeKeyBindings${recursive ? '' : 'NonRecursive'}Map`;
+function keyBindingsConfigKey(mode: string): string {
+  return `${mode}ModeKeyBindingsMap`;
 }
 
 class InsertModeRemapper extends Remapper {
-  constructor(recursive: boolean) {
-    super(keyBindingsConfigKey('insert', recursive), [Mode.Insert, Mode.Replace], recursive);
+  constructor() {
+    super(keyBindingsConfigKey('insert'), [Mode.Insert, Mode.Replace]);
   }
 }
 
 class NormalModeRemapper extends Remapper {
-  constructor(recursive: boolean) {
-    super(keyBindingsConfigKey('normal', recursive), [Mode.Normal], recursive);
+  constructor() {
+    super(keyBindingsConfigKey('normal'), [Mode.Normal]);
+  }
+}
+
+class OperatorPendingModeRemapper extends Remapper {
+  constructor() {
+    super(keyBindingsConfigKey('operatorPending'), [Mode.OperatorPendingMode]);
   }
 }
 
 class VisualModeRemapper extends Remapper {
-  constructor(recursive: boolean) {
-    super(
-      keyBindingsConfigKey('visual', recursive),
-      [Mode.Visual, Mode.VisualLine, Mode.VisualBlock],
-      recursive
-    );
+  constructor() {
+    super(keyBindingsConfigKey('visual'), [Mode.Visual, Mode.VisualLine, Mode.VisualBlock]);
   }
 }
 
 class CommandLineModeRemapper extends Remapper {
-  constructor(recursive: boolean) {
-    super(
-      keyBindingsConfigKey('commandLine', recursive),
-      [Mode.CommandlineInProgress, Mode.SearchInProgressMode],
-      recursive
-    );
+  constructor() {
+    super(keyBindingsConfigKey('commandLine'), [
+      Mode.CommandlineInProgress,
+      Mode.SearchInProgressMode,
+    ]);
   }
 }

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -22,8 +22,15 @@ export class RemappingValidator implements IConfigurationValidator {
       'commandLineModeKeyBindingsNonRecursive',
     ];
     for (const modeKeyBindingsKey of modeKeyBindingsKeys) {
-      let keybindings = config[modeKeyBindingsKey];
+      let keybindings = config[modeKeyBindingsKey] as IKeyRemapping[];
       const isRecursive = modeKeyBindingsKey.indexOf('NonRecursive') === -1;
+
+      const defaultKeybindings = config['default' + modeKeyBindingsKey] as IKeyRemapping[];
+      // filter the default keybindings whose 'after' already has a map to by the user
+      const filteredDefaultKeybindings = defaultKeybindings.filter(
+        (dkb) => keybindings.find((kb) => dkb.after && dkb.after === kb.after) === undefined
+      );
+      keybindings.push(...filteredDefaultKeybindings);
 
       const modeMapName = modeKeyBindingsKey.replace('NonRecursive', '');
       let modeKeyBindingsMap = config[modeMapName + 'Map'] as Map<string, IKeyRemapping>;

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -140,6 +140,8 @@ export class RemappingValidator implements IConfigurationValidator {
           return config.replaceWithRegister;
         case 'sneak':
           return config.sneak;
+        case 'surround':
+          return config.surround;
         default:
           return false;
       }

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -104,8 +104,9 @@ export class RemappingValidator implements IConfigurationValidator {
       }
 
       const hasMapTo =
-        existingBindings.find((ekb) => keybinding.after && keybinding.after === ekb.after) !==
-        undefined;
+        existingBindings.find(
+          (ekb) => keybinding.after && keybinding.after.join('') === ekb.after?.join('')
+        ) !== undefined;
 
       if (hasMapTo) {
         continue;

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -26,9 +26,12 @@ export class RemappingValidator implements IConfigurationValidator {
       const isRecursive = modeKeyBindingsKey.indexOf('NonRecursive') === -1;
 
       const defaultKeybindings = config['default' + modeKeyBindingsKey] as IKeyRemapping[];
-      // filter the default keybindings whose 'after' already has a map to by the user
+      // filter out the default keybindings whose 'after' already has a map to by the user and
+      // the ones whose plugin is not active
       const filteredDefaultKeybindings = defaultKeybindings.filter(
-        (dkb) => keybindings.find((kb) => dkb.after && dkb.after === kb.after) === undefined
+        (dkb) =>
+          keybindings.find((kb) => dkb.after && dkb.after === kb.after) === undefined &&
+          this.isPluginActive(config, (dkb as any).plugin)
       );
       keybindings.push(...filteredDefaultKeybindings);
 
@@ -87,6 +90,21 @@ export class RemappingValidator implements IConfigurationValidator {
 
   disable(config: IConfiguration) {
     // no-op
+  }
+
+  private isPluginActive(config: IConfiguration, pluginName: string | undefined) {
+    if (!pluginName) {
+      return true;
+    } else {
+      switch (pluginName) {
+        case 'camelcasemotion':
+          return config.camelCaseMotion.enable;
+        case 'easymotion':
+          return config.easymotion;
+        default:
+          return false;
+      }
+    }
   }
 
   private async isRemappingValid(remapping: IKeyRemapping): Promise<ValidatorResults> {

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -135,6 +135,8 @@ export class RemappingValidator implements IConfigurationValidator {
           return config.camelCaseMotion.enable;
         case 'easymotion':
           return config.easymotion;
+        case 'replacewithregister':
+          return config.replaceWithRegister;
         default:
           return false;
       }

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -138,6 +138,8 @@ export class RemappingValidator implements IConfigurationValidator {
           return config.easymotion;
         case 'replacewithregister':
           return config.replaceWithRegister;
+        case 'sneak':
+          return config.sneak;
         default:
           return false;
       }

--- a/src/configuration/validators/remappingValidator.ts
+++ b/src/configuration/validators/remappingValidator.ts
@@ -41,7 +41,7 @@ export class RemappingValidator implements IConfigurationValidator {
         modeKeyBindingsMap = new Map<string, IKeyRemapping>();
       }
       for (let i = keybindings.length - 1; i >= 0; i--) {
-        let remapping = keybindings[i] as IKeyRemapping;
+        let remapping = keybindings[i];
 
         // set 'recursive' of the remapping according to where it was stored
         remapping.recursive = isRecursive;

--- a/src/configuration/vimrc.ts
+++ b/src/configuration/vimrc.ts
@@ -8,7 +8,7 @@ import { vimrcKeyRemappingBuilder } from './vimrcKeyRemappingBuilder';
 import { window } from 'vscode';
 import { configuration } from './configuration';
 
-class VimrcImpl {
+export class VimrcImpl {
   private _vimrcPath: string;
 
   /**
@@ -56,6 +56,17 @@ class VimrcImpl {
           const remap = await vimrcKeyRemappingBuilder.build(line);
           if (remap) {
             VimrcImpl.addRemapToConfig(config, remap);
+            continue;
+          }
+          const unremap = await vimrcKeyRemappingBuilder.buildUnmapping(line);
+          if (unremap) {
+            VimrcImpl.removeRemapFromConfig(config, unremap);
+            continue;
+          }
+          const clearRemap = await vimrcKeyRemappingBuilder.buildClearMapping(line);
+          if (clearRemap) {
+            VimrcImpl.clearRemapsFromConfig(config, clearRemap);
+            continue;
           }
         }
       } catch (err) {
@@ -67,32 +78,115 @@ class VimrcImpl {
   /**
    * Adds a remapping from .vimrc to the given configuration
    */
-  private static addRemapToConfig(config: IConfiguration, remap: IVimrcKeyRemapping): void {
+  public static addRemapToConfig(config: IConfiguration, remap: IVimrcKeyRemapping): void {
     const mappings = (() => {
       switch (remap.keyRemappingType) {
         case 'map':
-          return [config.normalModeKeyBindings, config.visualModeKeyBindings];
+          return [
+            config.normalModeKeyBindings,
+            config.visualModeKeyBindings,
+            config.operatorPendingModeKeyBindings,
+          ];
         case 'nmap':
+        case 'nma':
+        case 'nm':
           return [config.normalModeKeyBindings];
         case 'vmap':
+        case 'vma':
+        case 'vm':
+        case 'xmap':
+        case 'xma':
+        case 'xm':
           return [config.visualModeKeyBindings];
         case 'imap':
+        case 'ima':
+        case 'im':
           return [config.insertModeKeyBindings];
         case 'cmap':
+        case 'cma':
+        case 'cm':
           return [config.commandLineModeKeyBindings];
+        case 'omap':
+        case 'oma':
+        case 'om':
+          return [config.operatorPendingModeKeyBindings];
+        case 'lmap':
+        case 'lma':
+        case 'lm':
+        case 'map!':
+          return [config.insertModeKeyBindings, config.commandLineModeKeyBindings];
         case 'noremap':
+        case 'norema':
+        case 'norem':
+        case 'nore':
+        case 'nor':
+        case 'no':
           return [
             config.normalModeKeyBindingsNonRecursive,
             config.visualModeKeyBindingsNonRecursive,
+            config.operatorPendingModeKeyBindingsNonRecursive,
           ];
         case 'nnoremap':
+        case 'nnorema':
+        case 'nnorem':
+        case 'nnore':
+        case 'nnor':
+        case 'nno':
+        case 'nn':
           return [config.normalModeKeyBindingsNonRecursive];
         case 'vnoremap':
+        case 'vnorema':
+        case 'vnorem':
+        case 'vnore':
+        case 'vnor':
+        case 'vno':
+        case 'vn':
+        case 'xnoremap':
+        case 'xnorema':
+        case 'xnorem':
+        case 'xnore':
+        case 'xnor':
+        case 'xno':
+        case 'xn':
           return [config.visualModeKeyBindingsNonRecursive];
         case 'inoremap':
+        case 'inorema':
+        case 'inorem':
+        case 'inore':
+        case 'inor':
+        case 'ino':
           return [config.insertModeKeyBindingsNonRecursive];
         case 'cnoremap':
+        case 'cnorema':
+        case 'cnorem':
+        case 'cnore':
+        case 'cnor':
+        case 'cno':
           return [config.commandLineModeKeyBindingsNonRecursive];
+        case 'onoremap':
+        case 'onorema':
+        case 'onorem':
+        case 'onore':
+        case 'onor':
+        case 'ono':
+          return [config.operatorPendingModeKeyBindingsNonRecursive];
+        case 'lnoremap':
+        case 'lnorema':
+        case 'lnorem':
+        case 'lnore':
+        case 'lnor':
+        case 'lno':
+        case 'ln':
+        case 'noremap!':
+        case 'norema!':
+        case 'norem!':
+        case 'nore!':
+        case 'nor!':
+        case 'no!':
+          return [
+            config.insertModeKeyBindingsNonRecursive,
+            config.commandLineModeKeyBindingsNonRecursive,
+          ];
         default:
           console.warn(`Encountered an unrecognized mapping type: '${remap.keyRemappingType}'`);
           return undefined;
@@ -107,13 +201,193 @@ class VimrcImpl {
     });
   }
 
-  private static removeAllRemapsFromConfig(config: IConfiguration): void {
+  /**
+   * Removes a remapping from .vimrc from the given configuration
+   */
+  public static removeRemapFromConfig(config: IConfiguration, remap: IVimrcKeyRemapping): boolean {
+    const mappings = (() => {
+      switch (remap.keyRemappingType) {
+        case 'unmap':
+        case 'unma':
+        case 'unm':
+          return [
+            config.normalModeKeyBindings,
+            config.normalModeKeyBindingsNonRecursive,
+            config.visualModeKeyBindings,
+            config.visualModeKeyBindingsNonRecursive,
+            config.operatorPendingModeKeyBindings,
+            config.operatorPendingModeKeyBindingsNonRecursive,
+          ];
+        case 'nunmap':
+        case 'nunma':
+        case 'nunm':
+        case 'nun':
+          return [config.normalModeKeyBindings, config.normalModeKeyBindingsNonRecursive];
+        case 'vunmap':
+        case 'vunma':
+        case 'vunm':
+        case 'vun':
+        case 'vu':
+        case 'xunmap':
+        case 'xunma':
+        case 'xunm':
+        case 'xun':
+        case 'xu':
+          return [config.visualModeKeyBindings, config.visualModeKeyBindingsNonRecursive];
+        case 'iunmap':
+        case 'iunma':
+        case 'iunm':
+        case 'iun':
+        case 'iu':
+          return [config.insertModeKeyBindings, config.insertModeKeyBindingsNonRecursive];
+        case 'cunmap':
+        case 'cunma':
+        case 'cunm':
+        case 'cun':
+        case 'cu':
+          return [config.commandLineModeKeyBindings, config.commandLineModeKeyBindingsNonRecursive];
+        case 'ounmap':
+        case 'ounma':
+        case 'ounm':
+        case 'oun':
+        case 'ou':
+          return [
+            config.operatorPendingModeKeyBindings,
+            config.operatorPendingModeKeyBindingsNonRecursive,
+          ];
+        case 'lunmap':
+        case 'lunma':
+        case 'lunm':
+        case 'lun':
+        case 'lu':
+        case 'unmap!':
+        case 'unma!':
+        case 'unm!':
+          return [
+            config.insertModeKeyBindings,
+            config.insertModeKeyBindingsNonRecursive,
+            config.commandLineModeKeyBindings,
+            config.commandLineModeKeyBindingsNonRecursive,
+          ];
+        default:
+          console.warn(`Encountered an unrecognized unmapping type: '${remap.keyRemappingType}'`);
+          return undefined;
+      }
+    })();
+
+    if (mappings) {
+      mappings.forEach((remaps) => {
+        // Don't remove a mapping present in settings.json; those are more specific to VSCodeVim.
+        _.remove(
+          remaps,
+          (r) => r.source === 'vimrc' && _.isEqual(r.before, remap.keyRemapping.before)
+        );
+      });
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Clears all remappings from .vimrc from the given configuration for specific mode
+   */
+  public static clearRemapsFromConfig(config: IConfiguration, remap: IVimrcKeyRemapping): boolean {
+    const mappings = (() => {
+      switch (remap.keyRemappingType) {
+        case 'mapclear':
+        case 'mapclea':
+        case 'mapcle':
+        case 'mapcl':
+        case 'mapc':
+          return [
+            config.normalModeKeyBindings,
+            config.normalModeKeyBindingsNonRecursive,
+            config.visualModeKeyBindings,
+            config.visualModeKeyBindingsNonRecursive,
+            config.operatorPendingModeKeyBindings,
+            config.operatorPendingModeKeyBindingsNonRecursive,
+          ];
+        case 'nmapclear':
+        case 'nmapclea':
+        case 'nmapcle':
+        case 'nmapcl':
+        case 'nmapc':
+          return [config.normalModeKeyBindings, config.normalModeKeyBindingsNonRecursive];
+        case 'vmapclear':
+        case 'vmapclea':
+        case 'vmapcle':
+        case 'vmapcl':
+        case 'vmapc':
+        case 'xmapclear':
+        case 'xmapclea':
+        case 'xmapcle':
+        case 'xmapcl':
+        case 'xmapc':
+          return [config.visualModeKeyBindings, config.visualModeKeyBindingsNonRecursive];
+        case 'imapclear':
+        case 'imapclea':
+        case 'imapcle':
+        case 'imapcl':
+        case 'imapc':
+          return [config.insertModeKeyBindings, config.insertModeKeyBindingsNonRecursive];
+        case 'cmapclear':
+        case 'cmapclea':
+        case 'cmapcle':
+        case 'cmapcl':
+        case 'cmapc':
+          return [config.commandLineModeKeyBindings, config.commandLineModeKeyBindingsNonRecursive];
+        case 'omapclear':
+        case 'omapclea':
+        case 'omapcle':
+        case 'omapcl':
+        case 'omapc':
+          return [
+            config.operatorPendingModeKeyBindings,
+            config.operatorPendingModeKeyBindingsNonRecursive,
+          ];
+        case 'lmapclear':
+        case 'lmapclea':
+        case 'lmapcle':
+        case 'lmapcl':
+        case 'lmapc':
+        case 'mapclear!':
+        case 'mapclea!':
+        case 'mapcle!':
+        case 'mapcl!':
+        case 'mapc!':
+          return [
+            config.insertModeKeyBindings,
+            config.insertModeKeyBindingsNonRecursive,
+            config.commandLineModeKeyBindings,
+            config.commandLineModeKeyBindingsNonRecursive,
+          ];
+        default:
+          console.warn(
+            `Encountered an unrecognized clearMapping type: '${remap.keyRemappingType}'`
+          );
+          return undefined;
+      }
+    })();
+
+    if (mappings) {
+      mappings.forEach((remaps) => {
+        // Don't remove a mapping present in settings.json; those are more specific to VSCodeVim.
+        _.remove(remaps, (r) => r.source === 'vimrc');
+      });
+      return true;
+    }
+    return false;
+  }
+
+  public static removeAllRemapsFromConfig(config: IConfiguration): void {
     const remapCollections = [
       config.normalModeKeyBindings,
+      config.operatorPendingModeKeyBindings,
       config.visualModeKeyBindings,
       config.insertModeKeyBindings,
       config.commandLineModeKeyBindings,
       config.normalModeKeyBindingsNonRecursive,
+      config.operatorPendingModeKeyBindingsNonRecursive,
       config.visualModeKeyBindingsNonRecursive,
       config.insertModeKeyBindingsNonRecursive,
       config.commandLineModeKeyBindingsNonRecursive,

--- a/src/configuration/vimrcKeyRemappingBuilder.ts
+++ b/src/configuration/vimrcKeyRemappingBuilder.ts
@@ -2,9 +2,135 @@ import * as vscode from 'vscode';
 import { IKeyRemapping, IVimrcKeyRemapping } from './iconfiguration';
 
 class VimrcKeyRemappingBuilderImpl {
-  private static readonly KEY_REMAPPING_REG_EX = /(^.*map)\s([\S]+)\s+(?!<Plug>)([\S]+)$/;
+  /**
+   * Regex for mapping lines
+   *
+   * * `^(` -> start of mapping type capture
+   *   * `map!?`\
+   *   _matches:_
+   *    * :map
+   *    * :map!
+   *
+   *   * `|smap`\
+   *   _matches:_
+   *    * :smap
+   *
+   *   * `|[nvxoilc]m(?:a(?:p)?)?`\
+   *   _matches:_
+   *    * :nm[ap]
+   *    * :vm[ap]
+   *    * :xm[ap]
+   *    * :om[ap]
+   *    * :im[ap]
+   *    * :lm[ap]
+   *    * :cm[ap]
+   *
+   *   * `|(?:`
+   *     * `[nvxl]no?r?|`\
+   *     _matches:_
+   *      * :nn[or]
+   *      * :vn[or]
+   *      * :xn[or]
+   *      * :ln[or]
+   *
+   *     * `[oic]nor?|`\
+   *     _matches:_
+   *      * :ono[r]
+   *      * :ino[r]
+   *      * :cno[r]
+   *
+   *     * `snor`\
+   *     _matches:_
+   *      * :snor
+   *   * `)(?:e(?:m(?:a(?:p)?)?)?)?`\
+   *     _matches the remaining optional [emap]_
+   *
+   *   * `|no(?:r(?:e(?:m(?:a(?:p)?)?)?)?)?!?`\
+   *   _matches:_
+   *    * :no[remap]
+   *    * :no[remap]!
+   * * `)` -> end of mapping type capture
+   *
+   * * `(?!.*(?:<expr>|<script>))` -> don't allow mappings with <expr> or <script> arguments
+   * * `(?:(?:<buffer>|<silent>|<nowait>|<special>)\s?)*` -> allow any of these arguments without capture
+   * * `([\S]+)\s+` -> match the {lhs} (we call it 'before')
+   * * `(?!.*<Plug>|.*<SID>)` -> don't allow mappings with <Plug> or <SID>
+   * * `([\S ]+)$` -> match the {rhs} (we call it 'after') allowing spaces for commands like `:edit {file}<CR>`
+   */
+  private static readonly KEY_REMAPPING_REG_EX = /^(map!?|smap|[nvxoilc]m(?:a(?:p)?)?|(?:[nvxl]no?r?|[oic]nor?|snor)(?:e(?:m(?:a(?:p)?)?)?)?|no(?:r(?:e(?:m(?:a(?:p)?)?)?)?)?!?)\s+(?!.*(?:<expr>|<script>))(?:(?:<buffer>|<silent>|<nowait>|<special>)\s?)*([\S]+)\s+(?!.*<Plug>|.*<SID>)([\S ]+)$/i;
+
+  /**
+   * Regex for unmapping lines
+   *
+   * * `^(` -> start of mapping type capture
+   *   * `unm(?:a(?:p)?)?!?`\
+   *   _matches:_
+   *    * :unm[ap]
+   *    * :unm[ap]!
+   *
+   *   * `|[nvxoilc]u(?:n(?:m(?:a(?:p)?)?)?)?`\
+   *   _matches:_
+   *    * :nu[nmap]
+   *    * :vu[nmap]
+   *    * :xu[nmap]
+   *    * :ou[nmap]
+   *    * :iu[nmap]
+   *    * :lu[nmap]
+   *    * :cu[nmap]
+   *
+   *   * `|sunm(?:a(?:p)?)?`\
+   *   _matches:_
+   *    * :sunm[ap]
+   * * `)` -> end of mapping type capture
+   *
+   * * `(?:(?:<buffer>|<silent>|<nowait>|<special>)\s?)*` -> allow any of these arguments without capture
+   * * `([\S]+)$` -> match the {lhs} (we call it 'before')
+   */
+  private static readonly KEY_UNREMAPPING_REG_EX = /^(unm(?:a(?:p)?)?!?|[nvxoilc]u(?:n(?:m(?:a(?:p)?)?)?)?|sunm(?:a(?:p)?)?)\s+(?:(?:<buffer>|<silent>|<nowait>|<special>)\s?)*([\S]+)$/i;
+
+  /**
+   * Regex for clear mapping lines
+   *
+   * * `^(` -> start of mapping clear type capture
+   *   * `mapc(?:l(?:e(?:a(?:r)?)?)?)?!?`\
+   *   _matches:_
+   *    * :mapc[lear]
+   *    * :mapc[lear]!
+   *
+   *   * `[nvxsoilc]mapc(?:l(?:e(?:a(?:r)?)?)?)?`\
+   *   _matches:_
+   *    * :nmapc[lear]
+   *    * :vmapc[lear]
+   *    * :xmapc[lear]
+   *    * :smapc[lear]
+   *    * :omapc[lear]
+   *    * :imapc[lear]
+   *    * :lmapc[lear]
+   *    * :cmapc[lear]
+   * * `)` -> end of mapping clear type capture
+   *
+   * * `([\S]+)$` -> match the {lhs} (we call it 'before')
+   */
+  private static readonly KEY_CLEAR_REMAPPING_REG_EX = /^(mapc(?:l(?:e(?:a(?:r)?)?)?)?!?|[nvxsoilc]mapc(?:l(?:e(?:a(?:r)?)?)?)?)$/i;
+
+  /**
+   * Regex for each key of {lhs} and {rhs}
+   *
+   * `(`\
+   * `<[^>]+>` -> match any special key of type <key>\
+   * `|` -> or\
+   * `.` -> any key\
+   * `)`
+   */
   private static readonly KEY_LIST_REG_EX = /(<[^>]+>|.)/g;
-  private static readonly VIM_COMMAND_REG_EX = /^(:\w+)<[Cc][Rr]>$/;
+
+  /**
+   * Regex to match a Vim command like `:edit {file}<CR>`
+   *
+   * `^(:.+)` -> match ':' character plus 1 or more character for the command\
+   * `<[Cc][Rr]>$` -> match <CR> at the end of the command
+   */
+  private static readonly VIM_COMMAND_REG_EX = /^(:.+)<[Cc][Rr]>$/;
 
   /**
    * @returns A remapping if the given `line` parses to one, and `undefined` otherwise.
@@ -43,6 +169,55 @@ class VimrcKeyRemappingBuilderImpl {
         before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
         source: 'vimrc',
         ...command,
+      },
+      keyRemappingType: type,
+    };
+  }
+
+  /**
+   * @returns A remapping if the given `line` parses to one, and `undefined` otherwise.
+   */
+  public async buildUnmapping(line: string): Promise<IVimrcKeyRemapping | undefined> {
+    if (line.trimLeft().startsWith('"')) {
+      return;
+    }
+
+    const matches = VimrcKeyRemappingBuilderImpl.KEY_UNREMAPPING_REG_EX.exec(line);
+    if (!matches || matches.length < 3) {
+      return undefined;
+    }
+
+    const type = matches[1];
+    const before = matches[2];
+
+    return {
+      keyRemapping: {
+        before: VimrcKeyRemappingBuilderImpl.buildKeyList(before),
+        source: 'vimrc',
+      },
+      keyRemappingType: type,
+    };
+  }
+
+  /**
+   * @returns An empty remapping with its type if the given `line` parses to one, and `undefined` otherwise.
+   */
+  public async buildClearMapping(line: string): Promise<IVimrcKeyRemapping | undefined> {
+    if (line.trimLeft().startsWith('"')) {
+      return;
+    }
+
+    const matches = VimrcKeyRemappingBuilderImpl.KEY_CLEAR_REMAPPING_REG_EX.exec(line);
+    if (!matches || matches.length < 2) {
+      return undefined;
+    }
+
+    const type = matches[1];
+
+    return {
+      keyRemapping: {
+        before: ['<Nop>'],
+        source: 'vimrc',
       },
       keyRemappingType: type,
     };

--- a/src/error.ts
+++ b/src/error.ts
@@ -10,6 +10,7 @@ export enum ErrorCode {
   NoPreviousRegularExpression = 35,
   NoWriteSinceLastChange = 37,
   ErrorWritingToFile = 208,
+  RecursiveMapping = 223,
   NoStringUnderCursor = 348,
   SearchHitTop = 384,
   SearchHitBottom = 385,
@@ -29,6 +30,7 @@ export const ErrorMessage: IErrorMessage = {
   35: 'No previous regular expression',
   37: 'No write since last change (add ! to override)',
   208: 'Error writing to file',
+  223: 'Recursive mapping',
   348: 'No string under cursor',
   384: 'Search hit TOP without match for',
   385: 'Search hit BOTTOM without match for',
@@ -68,5 +70,19 @@ export class VimError extends Error {
 
   toString(): string {
     return `E${this.code}: ${this.message}`;
+  }
+}
+
+/**
+ * Used to stop a remapping or a chain of nested remappings after a VimError, a failed action
+ * or the force stop recursive mapping key (<C-c> or <Esc>). (Vim doc :help map-error)
+ */
+export class ForceStopRemappingError extends Error {
+  constructor(reason: string = 'StopRemapping') {
+    super(reason);
+  }
+
+  static fromVimError(vimError: VimError): ForceStopRemappingError {
+    return new ForceStopRemappingError(vimError.toString());
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,7 @@ export enum ErrorCode {
   ErrorWritingToFile = 208,
   RecursiveMapping = 223,
   NoStringUnderCursor = 348,
+  NothingInRegister = 353,
   SearchHitTop = 384,
   SearchHitBottom = 385,
   CannotCloseLastWindow = 444,
@@ -32,6 +33,7 @@ export const ErrorMessage: IErrorMessage = {
   208: 'Error writing to file',
   223: 'Recursive mapping',
   348: 'No string under cursor',
+  353: 'Nothing in register', // TODO: this needs an extra value ("Nothing in register x")
   384: 'Search hit TOP without match for',
   385: 'Search hit BOTTOM without match for',
   444: 'Cannot close last window',

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,4 @@
-import { IConfiguration } from './configuration/iconfiguration';
+import { IConfiguration, IKeyRemapping } from './configuration/iconfiguration';
 import { ModeHandler } from './mode/modeHandler';
 
 /**
@@ -16,4 +16,27 @@ export class Globals {
   static isTesting = false;
   static mockModeHandler: ModeHandler;
   static mockConfiguration: IConfiguration;
+  static mockConfigurationDefaultBindings: {
+    defaultNormalModeKeyBindings: IKeyRemapping[];
+    defaultNormalModeKeyBindingsNonRecursive: IKeyRemapping[];
+    defaultInsertModeKeyBindings: IKeyRemapping[];
+    defaultInsertModeKeyBindingsNonRecursive: IKeyRemapping[];
+    defaultVisualModeKeyBindings: IKeyRemapping[];
+    defaultVisualModeKeyBindingsNonRecursive: IKeyRemapping[];
+    defaultCommandLineModeKeyBindings: IKeyRemapping[];
+    defaultCommandLineModeKeyBindingsNonRecursive: IKeyRemapping[];
+    defaultOperatorPendingModeKeyBindings: IKeyRemapping[];
+    defaultOperatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[];
+  } = {
+    defaultNormalModeKeyBindings: [],
+    defaultNormalModeKeyBindingsNonRecursive: [],
+    defaultInsertModeKeyBindings: [],
+    defaultInsertModeKeyBindingsNonRecursive: [],
+    defaultVisualModeKeyBindings: [],
+    defaultVisualModeKeyBindingsNonRecursive: [],
+    defaultCommandLineModeKeyBindings: [],
+    defaultCommandLineModeKeyBindingsNonRecursive: [],
+    defaultOperatorPendingModeKeyBindings: [],
+    defaultOperatorPendingModeKeyBindingsNonRecursive: [],
+  };
 }

--- a/src/mode/mode.ts
+++ b/src/mode/mode.ts
@@ -16,6 +16,7 @@ export enum Mode {
   EasyMotionMode,
   EasyMotionInputMode,
   SurroundInputMode,
+  OperatorPendingMode, // Pseudo-Mode, used only when remapping. DON'T SET TO THIS MODE
   Disabled,
 }
 
@@ -124,26 +125,28 @@ export function statusBarCommandText(vimState: VimState): string {
       }
       const lines = end.line - start.line + 1;
       if (lines > 1) {
-        return `${lines}`;
+        return `${lines} ${vimState.recordedState.pendingCommandString}`;
       } else {
         const chars = Math.max(end.character - start.character, 1) + (wentOverEOL ? 1 : 0);
-        return `${chars}`;
+        return `${chars} ${vimState.recordedState.pendingCommandString}`;
       }
     }
     case Mode.VisualLine:
       return `${
         Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1
-      }`;
+      } ${vimState.recordedState.pendingCommandString}`;
     case Mode.VisualBlock: {
       const lines =
         Math.abs(vimState.cursorStopPosition.line - vimState.cursorStartPosition.line) + 1;
       const chars =
         Math.abs(vimState.cursorStopPosition.character - vimState.cursorStartPosition.character) +
         1;
-      return `${lines}x${chars}`;
+      return `${lines}x${chars} ${vimState.recordedState.pendingCommandString}`;
     }
-    case Mode.Normal:
+    case Mode.Insert:
     case Mode.Replace:
+      return vimState.recordedState.pendingCommandString;
+    case Mode.Normal:
     case Mode.Disabled:
       return vimState.recordedState.commandString;
     default:

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1187,7 +1187,7 @@ export class ModeHandler implements vscode.Disposable {
           break;
 
         case 'macro':
-          let recordedMacro = (await Register.get(vimState, transformation.register)).text;
+          let recordedMacro = (await Register.get(vimState, transformation.register))?.text;
           if (!(recordedMacro instanceof RecordedState)) {
             return vimState;
           }

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -14,7 +14,7 @@ import { Register, RegisterMode } from './../register/register';
 import { Remappers } from '../configuration/remapper';
 import { StatusBar } from '../statusBar';
 import { TextEditor } from './../textEditor';
-import { VimError, ErrorCode } from './../error';
+import { VimError, ErrorCode, ForceStopRemappingError } from './../error';
 import { VimState } from './../state/vimState';
 import { VsCodeContext } from '../util/vscode-context';
 import { commandLine } from '../cmd_line/commandLine';
@@ -25,8 +25,7 @@ import {
   CommandQuitRecordMacro,
   DocumentContentChangeAction,
   ActionOverrideCmdD,
-  CommandRegister,
-  CommandVisualMode,
+  CommandNumber,
 } from './../actions/commands/actions';
 import {
   areAnyTransformationsOverlapping,
@@ -41,6 +40,7 @@ import { reportSearch } from '../util/statusBarTextUtils';
 import { Notation } from '../configuration/notation';
 import { ModeHandlerMap } from './modeHandlerMap';
 import { EditorIdentity } from '../editorIdentity';
+import { SpecialKeys } from '../util/specialKeys';
 import { BaseOperator } from '../actions/operator';
 import { SearchByNCharCommand } from '../actions/plugins/easymotion/easymotion.cmd';
 
@@ -360,7 +360,25 @@ export class ModeHandler implements vscode.Disposable {
     const now = Number(new Date());
     const printableKey = Notation.printableKey(key);
 
+    // Check forceStopRemapping
+    if (this.vimState.forceStopRecursiveRemapping) {
+      this.vimState.forceStopRecursiveRemapping = false;
+      throw new ForceStopRemappingError('Forced by user');
+    }
+
     this._logger.debug(`handling key=${printableKey}.`);
+
+    if (
+      (key === SpecialKeys.TimeoutFinished ||
+        this.vimState.recordedState.bufferedKeys.length > 0) &&
+      this.vimState.recordedState.bufferedKeysTimeoutObj
+    ) {
+      // Handle the bufferedKeys or append the new key to the previously bufferedKeys
+      clearTimeout(this.vimState.recordedState.bufferedKeysTimeoutObj);
+      this.vimState.recordedState.bufferedKeysTimeoutObj = undefined;
+      this.vimState.recordedState.commandList = [...this.vimState.recordedState.bufferedKeys];
+      this.vimState.recordedState.bufferedKeys = [];
+    }
 
     // rewrite copy
     if (configuration.overrideCopy) {
@@ -392,49 +410,70 @@ export class ModeHandler implements vscode.Disposable {
     this.vimState.recordedState.commandList.push(key);
 
     const oldMode = this.vimState.currentMode;
+    const oldFullMode = this.vimState.currentModeIncludingPseudoModes;
     const oldVisibleRange = this.vimState.editor.visibleRanges[0];
     const oldStatusBarText = StatusBar.getText();
+    const oldWaitingForAnotherActionKey = this.vimState.recordedState.waitingForAnotherActionKey;
 
+    let handledAsRemap = false;
+    let handledAsAction = false;
     try {
-      const isWithinTimeout = now - this.vimState.lastKeyPressedTimestamp < configuration.timeout;
-      if (!isWithinTimeout) {
-        // sufficient time has elapsed since the prior keypress,
-        // only consider the last keypress for remapping
-        this.vimState.recordedState.commandList = [
-          this.vimState.recordedState.commandList[
-            this.vimState.recordedState.commandList.length - 1
-          ],
-        ];
-      }
-
-      let handled = false;
-      const isOperatorCombination = this.vimState.recordedState.operator;
+      // Handling special case for '0'. From Vim documentation (:help :map-modes)
+      // Special case: While typing a count for a command in Normal mode, mapping zero
+      // is disabled. This makes it possible to map zero without making it impossible
+      // to type a count with a zero.
+      const preventZeroRemap =
+        key === '0' && this.vimState.recordedState.getLastActionRun() instanceof CommandNumber;
 
       // Check for remapped keys if:
       // 1. We are not currently performing a non-recursive remapping
-      // 2. We are not in normal mode performing on an operator
-      //    Example: ciwjj should be remapped if jj -> <Esc> in insert mode
-      //             dd should not remap the second "d", if d -> "_d in normal mode
+      // 2. We are not typing '0' after starting to type a count
+      // 3. We are not waiting for another action key
+      //    Example: jj should not remap the second 'j', if jj -> <Esc> in insert mode
+      //             0 should not be remapped if typed after another number, like 10
+      //             for actions with multiple keys like 'gg' or 'fx' the second character
+      //           shouldn't be mapped
       if (
-        !this.vimState.isCurrentlyPerformingRemapping &&
-        (!isOperatorCombination || this.vimState.currentMode !== Mode.Normal)
+        !this.vimState.isCurrentlyPerformingNonRecursiveRemapping &&
+        !preventZeroRemap &&
+        !this.vimState.recordedState.waitingForAnotherActionKey
       ) {
-        handled = await this._remappers.sendKey(
+        handledAsRemap = await this._remappers.sendKey(
           this.vimState.recordedState.commandList,
           this,
           this.vimState
         );
       }
 
-      if (handled) {
-        this.vimState.recordedState.resetCommandList();
-      } else {
-        this.vimState = await this.handleKeyEventHelper(key, this.vimState);
+      this.vimState.recordedState.allowPotentialRemapOnFirstKey = true;
+
+      if (!handledAsRemap) {
+        if (key === SpecialKeys.TimeoutFinished) {
+          // Remove the <TimeoutFinished> key and get the key before that. If the <TimeoutFinished>
+          // key was the last key, then 'key' will be undefined and won't be sent to handle action.
+          this.vimState.recordedState.commandList.pop();
+          key = this.vimState.recordedState.commandList[
+            this.vimState.recordedState.commandList.length - 1
+          ];
+        }
+        if (key !== undefined) {
+          handledAsAction = await this.handleKeyAsAnAction(key, this.vimState);
+        }
       }
     } catch (e) {
       this.vimState.selectionsChanged.ignoreIntermediateSelections = false;
       if (e instanceof VimError) {
         StatusBar.displayError(this.vimState, e);
+        this.vimState.recordedState = new RecordedState();
+        if (this.vimState.isCurrentlyPerformingRemapping) {
+          // If we are handling a remap and we got a VimError stop handling the remap
+          // and discard the rest of the keys. We throw an Exception here to stop any other
+          // remapping handling steps and go straight to the 'finally' step of the remapper.
+          throw ForceStopRemappingError.fromVimError(e);
+        }
+      } else if (e instanceof ForceStopRemappingError) {
+        // If this is a ForceStopRemappingError rethrow it until it gets to the remapper
+        throw e;
       } else if (e instanceof Error) {
         e.message = `Failed to handle key=${key}. ${e.message}`;
         throw e;
@@ -444,6 +483,8 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     this.vimState.lastKeyPressedTimestamp = now;
+
+    StatusBar.updateShowCmd(this.vimState);
 
     // We don't want to immediately erase any message that resulted from the action just performed
     if (StatusBar.getText() === oldStatusBarText) {
@@ -456,13 +497,57 @@ export class ModeHandler implements vscode.Disposable {
       StatusBar.clear(this.vimState, forceClearStatusBar);
     }
 
+    // We either already ran an action or we have a potential action to run but
+    // the key is already stored on 'actionKeys' in that case we don't need it
+    // anymore on commandList that is only used for the remapper and 'showCmd'
+    // and both had already been handled at this point.
+    // If we got here it means that there is no potential remap for the key
+    // either so we need to clear it from commandList so that it doesn't interfere
+    // with the next remapper check.
+    this.vimState.recordedState.resetCommandList();
+
     this._logger.debug(`handleKeyEvent('${printableKey}') took ${Number(new Date()) - now}ms`);
+
+    // If we are handling a remap and the last movement failed stop handling the remap
+    // and discard the rest of the keys. We throw an Exception here to stop any other
+    // remapping handling steps and go straight to the 'finally' step of the remapper.
+    if (this.vimState.isCurrentlyPerformingRemapping && this.vimState.lastMovementFailed) {
+      this.vimState.lastMovementFailed = false;
+      throw new ForceStopRemappingError('Last movement failed');
+    }
+
+    // Reset lastMovementFailed. Anyone who needed it has probably already handled it.
+    // And keeping it past this point would make any following remapping force stop.
+    this.vimState.lastMovementFailed = false;
+
+    if (!handledAsAction) {
+      // There was no action run yet but we still want to update the view to be able
+      // to show the potential remapping keys being pressed, the `"` character when
+      // waiting on a register key or the `?` character and any following character
+      // when waiting on digraph keys. The 'oldWaitingForAnotherActionKey' is used
+      // to call the updateView after we are no longer waiting keys so that any
+      // existing overlapped key is removed.
+      if (
+        ((this.vimState.currentMode === Mode.Insert ||
+          this.vimState.currentMode === Mode.Replace) &&
+          (this.vimState.recordedState.bufferedKeys.length > 0 ||
+            this.vimState.recordedState.waitingForAnotherActionKey ||
+            this.vimState.recordedState.waitingForAnotherActionKey !==
+              oldWaitingForAnotherActionKey)) ||
+        this.vimState.currentModeIncludingPseudoModes !== oldFullMode
+      ) {
+        // TODO: this call to updateView is only used to update the virtualCharacter and halfBlock
+        // cursor decorations, if in the future we split up the updateView function there should
+        // be no need to call all of it.
+        await this.updateView(this.vimState, { drawSelection: false, revealRange: false });
+      }
+    }
   }
 
-  private async handleKeyEventHelper(key: string, vimState: VimState): Promise<VimState> {
+  private async handleKeyAsAnAction(key: string, vimState: VimState): Promise<boolean> {
     if (vscode.window.activeTextEditor !== this.vimState.editor) {
       this._logger.warn('Current window is not active');
-      return this.vimState;
+      return false;
     }
 
     // Catch any text change not triggered by us (example: tab completion).
@@ -476,16 +561,28 @@ export class ModeHandler implements vscode.Disposable {
     const action = getRelevantAction(recordedState.actionKeys, vimState);
     switch (action) {
       case KeypressState.NoPossibleMatch:
-        if (!this._remappers.isPotentialRemap) {
-          vimState.recordedState = new RecordedState();
-        }
+        vimState.recordedState = new RecordedState();
+        // Since there is no possible action we are no longer waiting any action keys
+        vimState.recordedState.waitingForAnotherActionKey = false;
 
-        StatusBar.updateShowCmd(this.vimState);
-        return vimState;
+        return false;
       case KeypressState.WaitingOnKeys:
-        StatusBar.updateShowCmd(this.vimState);
-        return vimState;
+        vimState.recordedState.waitingForAnotherActionKey = true;
+
+        return false;
     }
+
+    if (!vimState.remapUsedACharacter && vimState.isCurrentlyPerformingRecursiveRemapping) {
+      // Used a character inside a recursive remapping so we reset the mapDepth.
+      vimState.remapUsedACharacter = true;
+      vimState.mapDepth = 0;
+    }
+
+    // Since we got an action we are no longer waiting any action keys
+    vimState.recordedState.waitingForAnotherActionKey = false;
+
+    // Store action pressed keys for showCmd
+    recordedState.actionsRunPressedKeys.push(...recordedState.actionKeys);
 
     let actionToRecord: BaseAction | undefined = action;
     if (recordedState.actionsRun.length === 0) {
@@ -549,11 +646,7 @@ export class ModeHandler implements vscode.Disposable {
       );
     }
 
-    if (!this._remappers.isPotentialRemap && recordedState.isInsertion) {
-      vimState.recordedState.resetCommandList();
-    }
-
-    return vimState;
+    return true;
   }
 
   private async runAction(
@@ -663,12 +756,6 @@ export class ModeHandler implements vscode.Disposable {
         ranRepeatableAction = true;
       }
     }
-    if (
-      (ranAction && !(action instanceof CommandRegister) && vimState.currentMode !== Mode.Insert) ||
-      action instanceof CommandVisualMode
-    ) {
-      vimState.recordedState.resetCommandList();
-    }
 
     ranRepeatableAction =
       (ranRepeatableAction && vimState.currentMode === Mode.Normal) ||
@@ -741,7 +828,11 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     // Don't record an undo point for every action of a macro, only at the very end
-    if (ranRepeatableAction && !vimState.isReplayingMacro) {
+    if (
+      ranRepeatableAction &&
+      !vimState.isReplayingMacro &&
+      !vimState.isCurrentlyPerformingRemapping
+    ) {
       vimState.historyTracker.finishCurrentStep();
     }
 
@@ -1312,7 +1403,7 @@ export class ModeHandler implements vscode.Disposable {
     if (showHighlights) {
       searchRanges = globalState.searchState?.getMatchRanges(this.vimState.editor.document) ?? [];
     }
-    this.vimState.editor.setDecorations(decoration.SearchHighlight, searchRanges);
+    this.vimState.editor.setDecorations(decoration.searchHighlight, searchRanges);
   }
 
   public async updateView(
@@ -1483,7 +1574,7 @@ export class ModeHandler implements vscode.Disposable {
     // cursor style
     let cursorStyle = configuration.getCursorStyleForMode(Mode[this.currentMode]);
     if (!cursorStyle) {
-      const cursorType = getCursorType(this.vimState, this.currentMode);
+      const cursorType = getCursorType(this.vimState, vimState.currentModeIncludingPseudoModes);
       cursorStyle = getCursorStyle(cursorType);
       if (
         cursorType === VSCodeVimCursorType.Native &&
@@ -1517,7 +1608,101 @@ export class ModeHandler implements vscode.Disposable {
       }
     }
 
-    this.vimState.editor.setDecorations(decoration.Default, cursorRange);
+    this.vimState.editor.setDecorations(decoration.default, cursorRange);
+
+    // Insert Mode virtual characters: used to temporarily show the remapping pressed keys on
+    // insert mode, to show the `"` character after pressing `<C-r>`, and to show `?` and the
+    // first character when inserting digraphs with `<C-k>`.
+    let iModeVirtualCharDecorationOptions: vscode.DecorationOptions[] = [];
+    if (this.vimState.currentMode === Mode.Insert || this.vimState.currentMode === Mode.Replace) {
+      let virtualKey: string | undefined = undefined;
+      if (vimState.recordedState.bufferedKeys.length > 0) {
+        virtualKey =
+          vimState.recordedState.bufferedKeys[vimState.recordedState.bufferedKeys.length - 1];
+      } else if (vimState.recordedState.waitingForAnotherActionKey) {
+        virtualKey =
+          vimState.recordedState.actionKeys[vimState.recordedState.actionKeys.length - 1];
+        if (virtualKey === '<C-r>') {
+          virtualKey = '"';
+        } else if (virtualKey === '<C-k>') {
+          virtualKey = '?';
+        } else {
+          // Don't show keys with `<` like `<C-x>` but show everything else
+          virtualKey = virtualKey.indexOf('<') >= 0 ? undefined : virtualKey;
+        }
+      }
+
+      if (virtualKey) {
+        // Normal Render Options with the key to overlap on the next character
+        const renderOptions: vscode.ThemableDecorationRenderOptions = {
+          before: {
+            contentText: virtualKey,
+          },
+        };
+
+        /**
+         * EOL Render Options:
+         * Some times when at the end of line the `currentColor` won't work, or it might be
+         * transparent, so we set the color to 'editor.foreground' when at EOL to avoid the
+         * virtualKey character not showing up.
+         */
+        const eolRenderOptions: vscode.ThemableDecorationRenderOptions = {
+          before: {
+            contentText: virtualKey,
+            color: new vscode.ThemeColor('editor.foreground'),
+          },
+        };
+
+        for (const { stop: cursorStop } of vimState.cursors) {
+          if (cursorStop.isLineEnd()) {
+            iModeVirtualCharDecorationOptions.push({
+              range: new vscode.Range(cursorStop, cursorStop.getLineEndIncludingEOL()),
+              renderOptions: eolRenderOptions,
+            });
+          } else {
+            iModeVirtualCharDecorationOptions.push({
+              range: new vscode.Range(cursorStop, cursorStop.getRightThroughLineBreaks(true)),
+              renderOptions: renderOptions,
+            });
+          }
+        }
+      }
+    }
+
+    this.vimState.editor.setDecorations(
+      decoration.insertModeVirtualCharacter,
+      iModeVirtualCharDecorationOptions
+    );
+
+    // OperatorPendingMode half block cursor
+    const opCursorDecorations: vscode.DecorationOptions[] = [];
+    const opCursorCharDecorations: vscode.DecorationOptions[] = [];
+    if (vimState.currentModeIncludingPseudoModes === Mode.OperatorPendingMode) {
+      for (const { stop: cursorStop } of vimState.cursors) {
+        let text = TextEditor.getCharAt(cursorStop);
+        // the ' ' (<space>) needs to be changed to '&nbsp;'
+        text = text === ' ' ? '\u00a0' : text;
+        const renderOptions: vscode.ThemableDecorationRenderOptions = {
+          before: {
+            contentText: text,
+          },
+        };
+        opCursorDecorations.push({
+          range: new vscode.Range(cursorStop, cursorStop.getRight()),
+          renderOptions: renderOptions,
+        });
+        opCursorCharDecorations.push({
+          range: new vscode.Range(cursorStop, cursorStop.getRight()),
+          renderOptions: renderOptions,
+        });
+      }
+    }
+
+    this.vimState.editor.setDecorations(decoration.operatorPendingModeCursor, opCursorDecorations);
+    this.vimState.editor.setDecorations(
+      decoration.operatorPendingModeCursorChar,
+      opCursorCharDecorations
+    );
 
     // TODO: draw marks (#3963)
 
@@ -1541,8 +1726,8 @@ export class ModeHandler implements vscode.Disposable {
             .getMatches(vimState.cursorStopPosition, vimState)
             .map((match) => match.toRange())
         : [];
-    this.vimState.editor.setDecorations(decoration.EasyMotionDimIncSearch, easyMotionDimRanges);
-    this.vimState.editor.setDecorations(decoration.EasyMotionIncSearch, easyMotionHighlightRanges);
+    this.vimState.editor.setDecorations(decoration.easyMotionDimIncSearch, easyMotionDimRanges);
+    this.vimState.editor.setDecorations(decoration.easyMotionIncSearch, easyMotionHighlightRanges);
 
     for (const viewChange of this.vimState.postponedCodeViewChanges) {
       await vscode.commands.executeCommand(viewChange.command, viewChange.args);
@@ -1555,7 +1740,6 @@ export class ModeHandler implements vscode.Disposable {
     }
 
     StatusBar.clear(this.vimState, false);
-    StatusBar.updateShowCmd(this.vimState);
 
     await VsCodeContext.Set('vim.mode', Mode[this.vimState.currentMode]);
 
@@ -1626,6 +1810,8 @@ function getCursorType(vimState: VimState, mode: Mode): VSCodeVimCursorType {
       return VSCodeVimCursorType.Block;
     case Mode.SurroundInputMode:
       return getCursorType(vimState, vimState.surround!.previousMode);
+    case Mode.OperatorPendingMode:
+      return VSCodeVimCursorType.Underline;
     case Mode.Disabled:
     default:
       return VSCodeVimCursorType.Line;

--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -359,6 +359,11 @@ export class ModeHandler implements vscode.Disposable {
   public async handleKeyEvent(key: string): Promise<void> {
     const now = Number(new Date());
     const printableKey = Notation.printableKey(key);
+    if (key === '<leader>') {
+      // this is only required for the plugins tests that might send this key instead of
+      // its representation. So we need to change it before sending it to remappers.
+      key = Notation.NormalizeKey(key, configuration.leader);
+    }
 
     // Check forceStopRemapping
     if (this.vimState.forceStopRecursiveRemapping) {

--- a/src/neovim/neovim.ts
+++ b/src/neovim/neovim.ts
@@ -141,13 +141,15 @@ export class NeovimWrapper implements vscode.Disposable {
     }
 
     // We only copy over " register for now, due to our weird handling of macros.
-    let reg = await Register.get(vimState);
-    let vsRegTovimReg = [undefined, 'c', 'l', 'b'];
-    await this.nvim.callFunction('setreg', [
-      '"',
-      reg.text as string,
-      vsRegTovimReg[vimState.effectiveRegisterMode] as string,
-    ]);
+    const reg = await Register.get(vimState, '"');
+    if (reg) {
+      const vsRegTovimReg = [undefined, 'c', 'l', 'b'];
+      await this.nvim.callFunction('setreg', [
+        '"',
+        reg.text as string,
+        vsRegTovimReg[vimState.effectiveRegisterMode] as string,
+      ]);
+    }
   }
 
   // Data flows from Vim to VSCode

--- a/src/register/register.ts
+++ b/src/register/register.ts
@@ -354,7 +354,10 @@ export class Register {
   /**
    * Gets content from a register. If no register is specified, uses `vimState.recordedState.registerName`.
    */
-  public static async get(vimState: VimState, register?: string): Promise<IRegisterContent> {
+  public static async get(
+    vimState: VimState,
+    register?: string
+  ): Promise<IRegisterContent | undefined> {
     if (register === undefined) {
       register = vimState.recordedState.registerName;
     }
@@ -363,16 +366,7 @@ export class Register {
       throw new Error(`Invalid register ${register}`);
     }
 
-    let lowercaseRegister = register.toLowerCase();
-
-    // Clipboard registers are always defined, so if a register doesn't already
-    // exist we can be sure it's not a clipboard one
-    if (!Register.registers.get(lowercaseRegister)) {
-      Register.registers.set(lowercaseRegister, {
-        text: '',
-        registerMode: RegisterMode.CharacterWise,
-      });
-    }
+    register = register.toLowerCase();
 
     /* Read from system clipboard */
     if (Register.isClipboardRegister(register)) {
@@ -393,36 +387,12 @@ export class Register {
 
       const registerContent = {
         text: registerText,
-        registerMode: Register.registers.get(lowercaseRegister)!.registerMode,
+        registerMode: Register.registers.get(register)?.registerMode ?? RegisterMode.CharacterWise,
       };
-      Register.registers.set(lowercaseRegister, registerContent);
+      Register.registers.set(register, registerContent);
       return registerContent;
     } else {
-      let text = Register.registers.get(lowercaseRegister)!.text;
-
-      let registerText: RegisterContent;
-      if (text instanceof RecordedState) {
-        registerText = text;
-      } else {
-        if (vimState && vimState.isMultiCursor && typeof text === 'object') {
-          if (text.length === vimState.cursors.length) {
-            registerText = text;
-          } else {
-            registerText = text.join('\n');
-          }
-        } else {
-          if (typeof text === 'object') {
-            registerText = text.join('\n');
-          } else {
-            registerText = text;
-          }
-        }
-      }
-
-      return {
-        text: registerText,
-        registerMode: Register.registers.get(lowercaseRegister)!.registerMode,
-      };
+      return Register.registers.get(register);
     }
   }
 

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -1,9 +1,10 @@
 import { configuration } from '../configuration/configuration';
-import { Mode } from '../mode/mode';
+import { Mode, isVisualMode } from '../mode/mode';
 import { BaseAction, BaseCommand } from './../actions/base';
 import { BaseOperator } from './../actions/operator';
 import { PositionDiff } from './../common/motion/position';
 import { Transformation } from './../transformations/transformations';
+import { SpecialKeys } from '../util/specialKeys';
 
 /**
  * The RecordedState class holds the current action that the user is
@@ -33,25 +34,63 @@ export class RecordedState {
   }
 
   /**
-   * The keys the user has pressed that have not caused an action to be
-   * executed yet. Used for showcmd and command remapping.
+   * The keys the user has pressed that have not caused an action to be executed
+   * yet and have not been stored on action keys. Used for command remapping.
    */
   public commandList: string[] = [];
 
   /**
-   * String representation of the exact keys that the user entered. Used for
-   * showcmd.
+   * String representation of the exact keys that the user entered.
    */
   public get commandString(): string {
     let result = '';
 
-    for (const key of this.commandList) {
-      if (key === configuration.leader) {
-        result += '<leader>';
-      } else {
-        result += key;
-      }
+    if (this.actionsRun.length > 0) {
+      result = this.actionsRunPressedKeys.join('');
     }
+    if (this.actionKeys.length > 0) {
+      // if there are any actionKeys waiting for other key append them
+      result += this.actionKeys.join('');
+    }
+    if (this.bufferedKeys.length > 0) {
+      // if there are any bufferedKeys waiting for other key append them
+      result += this.bufferedKeys.join('');
+    }
+    if (
+      this.actionsRun.length === 0 &&
+      this.actionKeys.length === 0 &&
+      this.bufferedKeys.length === 0 &&
+      this.commandList.length > 0
+    ) {
+      // Used for the registers and macros that only record on commandList
+      result = this.commandList.join('');
+    }
+    const regexEscape = new RegExp(/[|\\{}()[\]^$+*?.]/, 'g');
+    const regexLeader = new RegExp(configuration.leader.replace(regexEscape, '\\$&'), 'g');
+    const regexBufferedKeys = new RegExp(SpecialKeys.TimeoutFinished, 'g');
+    result = result.replace(regexLeader, '<leader>').replace(regexBufferedKeys, '');
+
+    return result;
+  }
+
+  /**
+   * String representation of the pending keys that the user entered.
+   */
+  public get pendingCommandString(): string {
+    let result = '';
+
+    if (this.actionKeys.length > 0) {
+      // if there are any actionKeys waiting for other key append them
+      result += this.actionKeys.join('');
+    }
+    if (this.bufferedKeys.length > 0) {
+      // if there are any bufferedKeys waiting for other key append them
+      result += this.bufferedKeys.join('');
+    }
+    const regexEscape = new RegExp(/[|\\{}()[\]^$+*?.]/, 'g');
+    const regexLeader = new RegExp(configuration.leader.replace(regexEscape, '\\$&'), 'g');
+    const regexBufferedKeys = new RegExp(SpecialKeys.TimeoutFinished, 'g');
+    result = result.replace(regexLeader, '<leader>').replace(regexBufferedKeys, '');
 
     return result;
   }
@@ -77,9 +116,40 @@ export class RecordedState {
   public actionKeys: string[] = [];
 
   /**
+   * Waiting for another key for a potential action.
+   *
+   * Used to prevent the remapping of keys after a potential action key
+   * like @zZtTfF[]rm'`"gq<C-r><C-w>. This is done to be able to use all
+   * the named registers and marks, even when the command with the same
+   * name has been mapped.
+   *
+   * Vim Documentation: (:help map-error)
+   * "Note that the second character (argument) of the commands @zZtTfF[]rm'`"v
+   * and CTRL-X is not mapped. This was done to be able to use all the named
+   * registers and marks, even when the command with the same name has been
+   * mapped."
+   *
+   * The documentation only specifies some keys, but from testing pretty much
+   * every key has this condition (keys like 'g', 'q', '<C-r>' and '<C-w>' all
+   * behave the same) so here we use 'waitingForAnotherActionKey' to prevent
+   * remapping on next keys. In the case of the 'v' key specified in the vim
+   * documentation, I don't really understand what they mean with that because
+   * it doesn't make much sense. The 'v' key puts you in Visual mode, it doesn't
+   * accept any character argument.
+   */
+  public waitingForAnotherActionKey: boolean = false;
+
+  /**
    * Every action that has been run.
    */
   public actionsRun: BaseAction[] = [];
+
+  /**
+   * Keeps track of keys pressed by the actionsRun. Used for the showCmd. If an action
+   * changes previous actions pressed keys it should change this list, like the <Del>
+   * key after a number key.
+   */
+  public actionsRunPressedKeys: string[] = [];
 
   public getLastActionRun(): BaseAction | undefined {
     if (this.actionsRun.length === 0) {
@@ -88,6 +158,29 @@ export class RecordedState {
 
     return this.actionsRun[this.actionsRun.length - 1];
   }
+
+  /**
+   * Every key that was buffered to wait for a new key or the timeout to finish
+   * in order to get another potential remap or to solve an ambiguous remap.
+   */
+  public bufferedKeys: string[] = [];
+  public bufferedKeysTimeoutObj: NodeJS.Timeout | undefined = undefined;
+
+  /**
+   * This is used when the remappers are resending the keys after a potential
+   * remap without an ambiguous remap is broken, either by a new key or by the
+   * timeout finishing.
+   *
+   * It will make it so the first key sent will not be considered as a potential
+   * remap by any of the remappers, even though it is, to prevent the remappers
+   * of doing the same thing again. This way the first key will be handled as an
+   * action but the next keys can still be remapped.
+   *
+   * Example: if you map `iiii -> i<C-A><Esc>` in normal mode and map `ii -> <Esc>`
+   * in insert mode, after pressing `iii` you want the first `i` to put you in
+   * insert mode and the next `ii` to escape to normal mode.
+   */
+  public allowPotentialRemapOnFirstKey = true;
 
   public hasRunOperator = false;
 
@@ -184,10 +277,25 @@ export class RecordedState {
       mode !== Mode.SearchInProgressMode &&
       mode !== Mode.CommandlineInProgress &&
       (this.hasRunAMovement ||
-        mode === Mode.Visual ||
-        mode === Mode.VisualLine ||
+        isVisualMode(mode) ||
         (this.operators.length > 1 &&
           this.operators.reverse()[0].constructor === this.operators.reverse()[1].constructor))
+    );
+  }
+
+  public isOperatorPending(mode: Mode): boolean {
+    // Visual modes do not require a motion -- they ARE the motion.
+    return (
+      this.operator !== undefined &&
+      !this.hasRunOperator &&
+      mode !== Mode.SearchInProgressMode &&
+      mode !== Mode.CommandlineInProgress &&
+      !(
+        this.hasRunAMovement ||
+        isVisualMode(mode) ||
+        (this.operators.length > 1 &&
+          this.operators.reverse()[0].constructor === this.operators.reverse()[1].constructor)
+      )
     );
   }
 }

--- a/src/state/recordedState.ts
+++ b/src/state/recordedState.ts
@@ -284,12 +284,10 @@ export class RecordedState {
   }
 
   public isOperatorPending(mode: Mode): boolean {
-    // Visual modes do not require a motion -- they ARE the motion.
     return (
       this.operator !== undefined &&
       !this.hasRunOperator &&
-      mode !== Mode.SearchInProgressMode &&
-      mode !== Mode.CommandlineInProgress &&
+      mode === Mode.Normal &&
       !(
         this.hasRunAMovement ||
         isVisualMode(mode) ||

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -106,6 +106,7 @@ export class VimState implements vscode.Disposable {
         replacement: string | undefined;
         range: Range | undefined;
         previousMode: Mode;
+        forcedRegisterMode: RegisterMode | undefined;
       } = undefined;
 
   /**

--- a/src/state/vimState.ts
+++ b/src/state/vimState.ts
@@ -12,6 +12,7 @@ import { Range } from './../common/motion/range';
 import { RecordedState } from './recordedState';
 import { RegisterMode } from './../register/register';
 import { ReplaceState } from './../state/replaceState';
+import { IKeyRemapping } from '../configuration/iconfiguration';
 
 interface INVim {
   run(vimState: VimState, command: string): Promise<{ statusBarText: string; error: boolean }>;
@@ -122,9 +123,110 @@ export class VimState implements vscode.Disposable {
   public postponedCodeViewChanges: ViewChange[] = [];
 
   /**
-   * Used to prevent non-recursive remappings from looping.
+   * Used to indicate that a non recursive remap is being handled. This is used to prevent non-recursive
+   * remappings from looping.
    */
-  public isCurrentlyPerformingRemapping = false;
+  public isCurrentlyPerformingNonRecursiveRemapping = false;
+
+  /**
+   * Used to indicate that a recursive remap is being handled. This is used to prevent recursive remappings
+   * from looping farther then maxMapDepth and to stop recursive remappings when an action fails.
+   */
+  public isCurrentlyPerformingRecursiveRemapping = false;
+
+  /**
+   * Used to indicate that a remap is being handled and the keys sent to modeHandler were not typed
+   * by the user.
+   */
+  public get isCurrentlyPerformingRemapping() {
+    return (
+      this.isCurrentlyPerformingNonRecursiveRemapping ||
+      this.isCurrentlyPerformingRecursiveRemapping
+    );
+  }
+
+  /**
+   * When performing a recursive remapping that has no parent remappings and that finishes while
+   * still waiting for timeout or another key to come we store that remapping here. This is used
+   * to be able to handle those buffered keys and any other key that the user might press to brake
+   * the timeout seperatly. Because if an error happens in the middle of a remap, the remaining
+   * remap keys shouldn't be handled but the user pressed ones should, but if an error happens on
+   * a user typed key, the following typed keys will still be handled.
+   *
+   * Example: having the following remapings:
+   * * `nmap <leader>lf Lfill`
+   * * `nmap Lfillc 4I<space><esc>`
+   * * `nmap Lfillp 2I<space><esc>`
+   * When user presses `<leader>lf` it remaps that to `Lfill` but because that is an ambiguous remap
+   * it creates the timeout and returns from remapper setting the performing remapping flag to false.
+   * This allows the user to then press `c` or `p` and the corresponding remap would run. But if the
+   * user presses another key or the timeout finishes we need to handle the `Lfill` keys and they
+   * need to know they were sent by a remap and not by the user so that in case the find 'i' in
+   * `Lfill` fails the last two `l` shouldn't be executed and any keys typed by the user after the
+   * remap that brake the timeout need to be handled seperatly from `Lfill`.
+   * (Check the tests for this example to understand better).
+   *
+   * To prevent this, we stored the remapping that finished waiting for timeout so that, if the
+   * timeout finishes or the user presses some keys that brake the potential remap, we will know
+   * what was the remapping waiting for timeout. So in case the timeout finishes we set the
+   * currently performing recursive remapping flag to true manually, send the <TimeoutFinished> key
+   * and in the end we set the flag back to false again and clear the stored remapping. In case
+   * the user presses one or more keys that brake the potential timeout we set the flag to true
+   * manually, handle the keys from the remapping and then set the flag back to false, clear the
+   * stored remapping and handle the keys pressed by the user seperatly.
+   * We do this because any VimError or ForceStopRemappingError are thrown only when performing a
+   * remapping.
+   */
+  public wasPerformingRemapThatFinishedWaitingForTimeout: IKeyRemapping | false = false;
+
+  /**
+   * Holds the current map depth count (number of nested remaps without using a character). In recursive remaps
+   * every time we map a key when already performing a remapping this number increases by one. When a remapping
+   * handling uses a character this number resets to 0.
+   *
+   * When it reaches the maxMapDepth it throws the VimError E223.
+   * (check vim documentation :help maxmapdepth)
+   */
+  public mapDepth: number = 0;
+
+  /**
+   * Used to reset the mapDepth on nested recursive remaps. Is set to false every time we get a remapping and is set to
+   * true when a character is used. We consider a character as being used when we get an action.
+   * (check vim documentation :help maxmapdepth).
+   *
+   * Example 1: if we remap `x -> y` and `y -> x` if we press any of those keys we will continuously find a new
+   * remap and increase the mapDepth without ever using an action until we hit maxMapDepth and we get E223 stopping
+   * it all.
+   *
+   * Example 2: if we map `a -> x`, `x -> y`, `y -> b` and `b -> w` and we set maxMapDepth to 4 we get 'E223 Recursive
+   * Mapping', because we get to the fourth remap without ever executing an action, but if we change the 'y' map to
+   * `y -> wb`, now the max mapDepth we hit is 3 and then we execute the action 'w' that resets the mapDepth and then
+   * call another remap of `b -> w` that executes another 'w', meaning that after pressing 'a' the result would be 'ww'.
+   * Another option would be to increase the maxMapDepth to 5 or more and then we could use the initial remaps that would
+   * turn the pressing of 'a' into a single 'w'.
+   *
+   * Example 3 (possible use case): if we remap `<leader>cb -> 0i//<Space><Esc>j<leader>cb` that recursively calls itself,
+   * every time the`0` key is sent we set remapUsedACharacter to true and reset mapDepth to 0 on all nested remaps so even
+   * if it calls itself more than 1000 times (on a file with more than 1000 lines) the mapDepth will always be reset to 0,
+   * which allows the remap to keep calling itself to comment all the lines until either we get to the last line and the 'j'
+   * action fails stopping the entire remap chain or the user presses `<C-c>` or `<Esc>` to forcelly stop the recursive remaps.
+   *
+   * P.S. This behavior is weird, because we should reduce the mapDepth by one when the remapping finished handling
+   * or if it failed. But this is the way Vim does it. This allows the user to create infinite looping remaps
+   * that call themselves and only stop after an error or the user pressing a key (usually <C-c> but we also
+   * allow <Esc> because the user might not allow the use of ctrl keys).
+   *
+   * P.S.2 This is a complicated explanation for a seemingly simple feature, but I wrote this because when I first read the
+   * Vim documentation it wasn't very clear to me how this worked, I first thought that mapDepth was like a map count but that
+   * is not the case because we can have thousands of nested remaps without ever hitting maxMapDepth like in Example 3, and I
+   * only started to understand it better when I tried Example 2 in Vim and some variations of it.
+   */
+  public remapUsedACharacter: boolean = false;
+
+  /**
+   * This will force Stop a recursive remapping. Used by <C-c> or <Esc> key when there is a recursive remapping
+   */
+  public forceStopRecursiveRemapping: boolean = false;
 
   /**
    * All the keys we've pressed so far.
@@ -236,6 +338,17 @@ export class VimState implements vscode.Disposable {
 
   public get currentMode(): Mode {
     return this._currentMode;
+  }
+
+  /**
+   * The mode Vim is currently including pseudo-modes like OperatorPendingMode
+   * This is to be used only by the Remappers when getting the remappings so don't
+   * use it anywhere else.
+   */
+  public get currentModeIncludingPseudoModes(): Mode {
+    return this.recordedState.isOperatorPending(this._currentMode)
+      ? Mode.OperatorPendingMode
+      : this._currentMode;
   }
 
   private _inputMethodSwitcher: InputMethodSwitcher;

--- a/src/util/specialKeys.ts
+++ b/src/util/specialKeys.ts
@@ -1,0 +1,5 @@
+export enum SpecialKeys {
+  ExtensionEnable = '<ExtensionEnable>',
+  ExtensionDisable = '<ExtensionDisable>',
+  TimeoutFinished = '<TimeoutFinished>',
+}

--- a/test/configuration/configuration.test.ts
+++ b/test/configuration/configuration.test.ts
@@ -29,8 +29,7 @@ suite('Configuration', () => {
 
   test('remappings are normalized', async () => {
     const normalizedKeybinds = srcConfiguration.configuration.normalModeKeyBindingsNonRecursive;
-    const normalizedKeybindsMap =
-      srcConfiguration.configuration.normalModeKeyBindingsNonRecursiveMap;
+    const normalizedKeybindsMap = srcConfiguration.configuration.normalModeKeyBindingsMap;
     const testingKeybinds = configuration.normalModeKeyBindingsNonRecursive;
 
     assert.strictEqual(normalizedKeybinds.length, testingKeybinds.length);

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -418,17 +418,17 @@ suite('Remapper', () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'line1', '<Esc>', '0']);
 
     const expected = 'text-to-put-on-register';
-    let actual: IRegisterContent;
+    let actual: IRegisterContent | undefined;
     Register.put(expected, modeHandler.vimState);
     actual = await Register.get(vimState);
-    assert.strictEqual(actual.text, expected);
+    assert.strictEqual(actual?.text, expected);
 
     // act
     await modeHandler.handleMultipleKeyEvents(['d', 'd']);
 
     // assert
     actual = await Register.get(vimState);
-    assert.strictEqual(actual.text, expected);
+    assert.strictEqual(actual?.text, expected);
   });
 
   test('d -> black hole register delete in normal mode through modehandler', async () => {
@@ -446,17 +446,17 @@ suite('Remapper', () => {
     await modeHandler.handleMultipleKeyEvents(['i', 'word1 word2', '<Esc>', '0']);
 
     const expected = 'text-to-put-on-register';
-    let actual: IRegisterContent;
+    let actual: IRegisterContent | undefined;
     Register.put(expected, modeHandler.vimState);
     actual = await Register.get(vimState);
-    assert.strictEqual(actual.text, expected);
+    assert.strictEqual(actual?.text, expected);
 
     // act
     await modeHandler.handleMultipleKeyEvents(['d', 'w']);
 
     // assert
     actual = await Register.get(vimState);
-    assert.strictEqual(actual.text, expected);
+    assert.strictEqual(actual?.text, expected);
   });
 
   test('jj -> <Esc> after ciw operator through modehandler', async () => {

--- a/test/configuration/remapper.test.ts
+++ b/test/configuration/remapper.test.ts
@@ -10,6 +10,8 @@ import { IKeyRemapping } from '../../src/configuration/iconfiguration';
 import { IRegisterContent, Register } from '../../src/register/register';
 import { getAndUpdateModeHandler } from '../../extension';
 import { VimState } from '../../src/state/vimState';
+import { TextEditor } from '../../src/textEditor';
+import { StatusBar } from '../../src/statusBar';
 
 /* tslint:disable:no-string-literal */
 
@@ -47,16 +49,18 @@ suite('Remapper', () => {
       ],
     },
     {
-      before: ['d'],
-      after: ['"', '_', 'd'],
-    },
-    {
       before: ['y', 'y'],
       after: ['y', 'l'],
     },
     {
       before: ['e'],
       after: ['$'],
+    },
+  ];
+  const defaultNormalModeKeyBindingsNonRecursive: IKeyRemapping[] = [
+    {
+      before: ['d'],
+      after: ['"', '_', 'd'],
     },
   ];
   const defaultVisualModeKeyBindings: IKeyRemapping[] = [
@@ -73,7 +77,7 @@ suite('Remapper', () => {
 
   class TestRemapper extends Remapper {
     constructor() {
-      super('configKey', [Mode.Insert], false);
+      super('configKey', [Mode.Insert]);
     }
 
     public findMatchingRemap(
@@ -94,16 +98,19 @@ suite('Remapper', () => {
   const setupWithBindings = async ({
     insertModeKeyBindings,
     normalModeKeyBindings,
+    normalModeKeyBindingsNonRecursive,
     visualModeKeyBindings,
   }: {
     insertModeKeyBindings?: IKeyRemapping[];
     normalModeKeyBindings?: IKeyRemapping[];
+    normalModeKeyBindingsNonRecursive?: IKeyRemapping[];
     visualModeKeyBindings?: IKeyRemapping[];
   }) => {
     const configuration = new Configuration();
     configuration.leader = leaderKey;
     configuration.insertModeKeyBindings = insertModeKeyBindings || [];
     configuration.normalModeKeyBindings = normalModeKeyBindings || [];
+    configuration.normalModeKeyBindingsNonRecursive = normalModeKeyBindingsNonRecursive || [];
     configuration.visualModeKeyBindings = visualModeKeyBindings || [];
 
     await setupWorkspace(configuration);
@@ -118,6 +125,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -140,6 +148,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -247,6 +256,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -282,6 +292,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -308,6 +319,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -343,6 +355,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -367,6 +380,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -394,6 +408,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -421,6 +436,7 @@ suite('Remapper', () => {
     await setupWithBindings({
       insertModeKeyBindings: defaultInsertModeKeyBindings,
       normalModeKeyBindings: defaultNormalModeKeyBindings,
+      normalModeKeyBindingsNonRecursive: defaultNormalModeKeyBindingsNonRecursive,
       visualModeKeyBindings: defaultVisualModeKeyBindings,
     });
 
@@ -547,6 +563,276 @@ suite('Remapper', () => {
 
     await modeHandler.handleMultipleKeyEvents(['u']);
     assertEqualLines(['foo']);
+  });
+
+  test('Recursive remap throws E223', async () => {
+    // setup
+    await setupWithBindings({
+      normalModeKeyBindings: [
+        {
+          before: ['x'],
+          after: ['y'],
+        },
+        {
+          before: ['y'],
+          after: ['x'],
+        },
+      ],
+    });
+
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'foo', '<Esc>']);
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+
+    // act
+    await modeHandler.handleMultipleKeyEvents(['x']);
+
+    // assert
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    assert.strictEqual(StatusBar.getText(), 'E223: Recursive mapping');
+    assertEqualLines(['foo']);
+  });
+
+  test('ambiguous and potential remaps and timeouts', async () => {
+    // setup
+    await setupWithBindings({
+      normalModeKeyBindings: [
+        {
+          before: ['w', 'w'],
+          after: ['d', 'w'],
+        },
+        {
+          before: ['w', 'w', 'w', 'w'],
+          after: ['d', 'd'],
+        },
+        {
+          before: ['b', 'b'],
+          after: ['d', 'd'],
+        },
+      ],
+    });
+
+    // Using the default timeout
+    const timeout = new Configuration().timeout;
+    // Offset because the timeout might not finish exactly on time.
+    const timeoutOffset = 250;
+
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+    await modeHandler.handleMultipleKeyEvents(['i', 'foo', ' ', 'bar', ' ', 'biz', '<Esc>', '0']);
+    assert.strictEqual(modeHandler.currentMode, Mode.Normal);
+    assertEqualLines(['foo bar biz']);
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.character,
+      0,
+      'Cursor is not on the right position, should be at the start of line'
+    );
+
+    // act and assert
+
+    // check that 'ww' -> 'dw' waits for timeout to finish and timeout isn't run twice
+    let result1: string[] = await new Promise(async (r1Resolve, r1Reject) => {
+      let p1: Promise<string> = new Promise((p1Resolve, p1Reject) => {
+        setTimeout(() => {
+          // get line after half timeout finishes
+          const currentLine = TextEditor.readLineAt(0);
+          p1Resolve(currentLine);
+        }, timeout / 2);
+      });
+      let p2: Promise<string> = new Promise((p2Resolve, p2Reject) => {
+        setTimeout(() => {
+          // get line after timeout + offset finishes
+          const currentLine = TextEditor.readLineAt(0);
+          p2Resolve(currentLine);
+        }, timeout + timeoutOffset);
+      });
+      let p3: Promise<string> = new Promise(async (p3Resolve, p3Reject) => {
+        await modeHandler.handleMultipleKeyEvents(['w', 'w']);
+        p3Resolve('modeHandler.handleMultipleKeyEvents finished');
+      });
+      await Promise.all([p1, p2, p3]).then((results) => {
+        r1Resolve(results);
+      });
+    });
+
+    // Before the timeout finishes it shouldn't have changed anything yet,
+    // because it is still waiting for a key or timeout to finish.
+    assert.strictEqual(result1[0], 'foo bar biz');
+
+    // After the timeout finishes (plus an offset to be sure it finished)
+    // it should have handled the remapping, if it wrongly ran the timeout
+    // twice this should fail too.
+    assert.strictEqual(result1[1], 'bar biz');
+
+    // check that 'www' -> 'dw' and then 'w' waits for timeout to finish
+    let result2: { line: string; position: number }[] = await new Promise(
+      async (r2Resolve, r2Reject) => {
+        let p1: Promise<{ line: string; position: number }> = new Promise((p1Resolve, p1Reject) => {
+          setTimeout(() => {
+            // get line and cursor character after half timeout finishes
+            const currentLine = TextEditor.readLineAt(0);
+            const cursorCharacter = modeHandler.vimState.cursorStopPosition.character;
+            p1Resolve({ line: currentLine, position: cursorCharacter });
+          }, timeout / 2);
+        });
+        let p2: Promise<{ line: string; position: number }> = new Promise((p2Resolve, p2Reject) => {
+          setTimeout(() => {
+            // get line and cursor character after timeout + offset finishes
+            const currentLine = TextEditor.readLineAt(0);
+            const cursorCharacter = modeHandler.vimState.cursorStopPosition.character;
+            p2Resolve({ line: currentLine, position: cursorCharacter });
+          }, timeout + timeoutOffset);
+        });
+        let p3: Promise<{ line: string; position: number }> = new Promise(
+          async (p3Resolve, p3Reject) => {
+            await modeHandler.handleMultipleKeyEvents(['w', 'w', 'w']);
+            p3Resolve({ line: 'modeHandler.handleMultipleKeyEvents finished', position: -1 });
+          }
+        );
+        await Promise.all([p1, p2, p3]).then((results) => {
+          r2Resolve(results);
+        });
+      }
+    );
+
+    // Before the timeout finishes it shouldn't have changed anything yet,
+    // because it is still waiting for a key or timeout to finish.
+    assert.strictEqual(result2[0].line, 'bar biz');
+    assert.strictEqual(
+      result2[0].position,
+      0,
+      'Cursor is not on the right position, should be at the start of line'
+    );
+
+    // After the timeout finishes (plus an offset to be sure it finished)
+    // it should have handled the remapping, if it wrongly ran the timeout
+    // twice this should fail too.
+    assert.strictEqual(result2[1].line, 'biz');
+    assert.strictEqual(
+      result2[1].position,
+      2,
+      'Cursor is not on the right position, should be at the end of line'
+    );
+
+    // add new line
+    await modeHandler.handleMultipleKeyEvents(['a', '\n', 'foo', '<Esc>']);
+    assertEqualLines(['biz', 'foo']);
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.character,
+      2,
+      'Cursor is not on the right position, should be at the end of line'
+    );
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.line,
+      1,
+      'Cursor is not on the right position, should be on second line'
+    );
+
+    // check that 'wwww' -> 'dd' doesn't wait for timeout
+    let result3 = await new Promise(async (r3Resolve, r3Reject) => {
+      const start = Number(new Date());
+
+      await modeHandler.handleMultipleKeyEvents(['w', 'w', 'w', 'w']).then(() => {
+        const now = Number(new Date());
+        const elapsed = now - start;
+
+        assertEqualLines(['biz']);
+        assert.strictEqual(
+          modeHandler.vimState.cursorStopPosition.character,
+          0,
+          'Cursor is not on the right position, shoul be at the start of line'
+        );
+        assert.strictEqual(
+          modeHandler.vimState.cursorStopPosition.line,
+          0,
+          'Cursor is not on the right position, should be on first line'
+        );
+
+        // We check if the elapsed time is less than half the timeout instead of
+        // just a few miliseconds to prevent any performance issue marking the
+        // test as failed when it would've succeeded. If it is less than half the
+        // timeout we can be sure the setTimeout was never ran.
+        assert.strictEqual(elapsed < timeout / 2, true);
+        r3Resolve("wwww -> dd doesn't wait for timeout to finish");
+      });
+    });
+
+    assert.strictEqual(result3, "wwww -> dd doesn't wait for timeout to finish");
+
+    // add new line again
+    await modeHandler.handleMultipleKeyEvents(['$', 'a', '\n', 'foo', '<Esc>']);
+    assertEqualLines(['biz', 'foo']);
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.character,
+      2,
+      'Cursor is not on the right position, should be at the end of line'
+    );
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.line,
+      1,
+      'Cursor is not on the right position, should be on second line'
+    );
+
+    // check 'bb' -> 'dd' sending each 'b' one by one checking between them to see
+    // that the remapping hasn't been handled yet and that the whole process
+    // doesn't take the timeout to finish
+
+    const startTime = Number(new Date());
+
+    // send first 'b'
+    await modeHandler.handleKeyEvent('b');
+
+    // should be the same
+    assertEqualLines(['biz', 'foo']);
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.character,
+      2,
+      'Cursor is not on the right position, should be at the end of line'
+    );
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.line,
+      1,
+      'Cursor is not on the right position, should be on second line'
+    );
+
+    // wait for 500 miliseconds (half of timeout) to simulate the time the user takes
+    // between presses. Not using a fixed value here in case the default configuration
+    // gets changed to use a lower value for timeout.
+    let waited: boolean = await new Promise((wResolve, wReject) => {
+      setTimeout(() => {
+        wResolve(true);
+      }, timeout / 2);
+    });
+    assert.strictEqual(waited, true);
+
+    // send second 'b'
+    await modeHandler.handleKeyEvent('b');
+
+    // check result and time elapsed
+    const elapsedTime = Number(new Date()) - startTime;
+
+    assertEqualLines(['biz']);
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.character,
+      0,
+      'Cursor is not on the right position, shoul be at the start of line'
+    );
+    assert.strictEqual(
+      modeHandler.vimState.cursorStopPosition.line,
+      0,
+      'Cursor is not on the right position, should be on first line'
+    );
+
+    // We check if the elapsedTime is less than the timeout minus an offset just
+    // to be sure that some performance issue doesn't make the test fail when it
+    // would succeed but this might not be foolproof, since we are dealing with
+    // times here.
+    //
+    // Note: I didn't want to use a Promise here again like previously, because I
+    // wanted to have both methods of testing (with and without promises) and this
+    // method should simulate better the real use from the user.
+    assert.strictEqual(elapsedTime < timeout - timeoutOffset, true);
   });
 });
 

--- a/test/configuration/remaps.test.ts
+++ b/test/configuration/remaps.test.ts
@@ -1,0 +1,1205 @@
+import * as assert from 'assert';
+import { getAndUpdateModeHandler } from '../../extension';
+import { Mode } from '../../src/mode/mode';
+import { ModeHandler } from '../../src/mode/modeHandler';
+import { Configuration } from '../testConfiguration';
+import { getTestingFunctions } from '../testSimplifier';
+import { cleanUpWorkspace, setupWorkspace } from '../testUtils';
+
+suite('Remaps', () => {
+  let modeHandler: ModeHandler;
+  const { newTestWithRemaps, newTestWithRemapsOnly, newTestWithRemapsSkip } = getTestingFunctions();
+
+  setup(async () => {
+    const configuration = new Configuration();
+    // The timeout shouldn't be lower then 200ms when testing because it might result in some tests
+    // failing when they shouldn't. I ran this test successfully with this timeout as low as 50ms, but
+    // lower than that I start getting some issues. I still set this a little bit higher because it
+    // might change from machine to machine.
+    configuration.timeout = 200;
+    configuration.leader = ' ';
+
+    await setupWorkspace(configuration);
+    modeHandler = await getAndUpdateModeHandler();
+  });
+
+  teardown(cleanUpWorkspace);
+
+  newTestWithRemaps({
+    title: 'Can handle ambiguous remaps on different recursiveness mappings',
+    start: ['|one two three'],
+    remaps: {
+      normalModeKeyBindings: [
+        {
+          before: ['<leader>', 'w'],
+          after: ['w'],
+        },
+        {
+          before: ['w', 'w'],
+          after: ['b'],
+        },
+      ],
+      normalModeKeyBindingsNonRecursive: [
+        {
+          before: ['w'],
+          after: ['w', 'w'],
+        },
+      ],
+    },
+    steps: [
+      {
+        // Step 0: Press keys '<space>w' that remap to 'w' but since 'w' is an ambiguous remap it waits
+        // for timeout or another key to come. In step result with 'end' we assert the result right after
+        // the keys are handled. When we use the 'endAfterTimeout' we are telling the test to wait for
+        // timeout to end and then assert the result.
+        keysPressed: ' w',
+        stepResult: {
+          end: ['|one two three'],
+          endAfterTimeout: ['one two |three'],
+        },
+      },
+      {
+        // Step 1: Again we press the keys '<space>w' that remaps to 'w' and waits for timeout and we assert
+        // that nothing has changed since the last result after the keys are handled.
+        keysPressed: ' w',
+        stepResult: {
+          end: ['one two |three'],
+        },
+      },
+      {
+        // Step 2: Since we didn't wait for timeout on the previous step it is still waiting for timeout to
+        // finish or another key to come so when we now press the key 'w' it gets 'ww' and remaps it to 'b'.
+        keysPressed: 'w',
+        stepResult: {
+          end: ['one |two three'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Potential and ambiguous remaps on different recursiveness mappings with different sizes are handled by the correct Remapper',
+    start: ['|one two three'],
+    remaps: {
+      normalModeKeyBindings: [
+        {
+          before: ['<leader>', 'b', 'b'],
+          after: ['w'],
+        },
+        {
+          before: ['<leader>', 'w'],
+          after: ['$'],
+        },
+        {
+          before: ['<leader>', 'e', 'e'],
+          after: ['i', 'e', 'e', '<Esc>'],
+        },
+        {
+          before: ['<leader>', 'l', 'l', 'l'],
+          after: ['i', 'l', 'l', 'l', '<Esc>'],
+        },
+      ],
+      normalModeKeyBindingsNonRecursive: [
+        {
+          before: ['<leader>', 'b'],
+          after: ['0'],
+        },
+        {
+          before: ['<leader>', 'w', 'w'],
+          after: ['b'],
+        },
+        {
+          before: ['<leader>', 'e', 'e', 'e'],
+          after: ['i', 'e', 'e', 'e', '<Esc>'],
+        },
+        {
+          before: ['<leader>', 'l', 'l'],
+          after: ['i', 'l', 'l', '<Esc>'],
+        },
+      ],
+    },
+    steps: [
+      {
+        // Step 0: Press keys '<space>w' that remap to '$' but since there is the '<space>ww' potential
+        // remap it waits for timeout or another key to come. The recursive remap needs to know that it
+        // has a potential remap and needs to wait but after timeout finishes it also needs to know that
+        // there is a NonRecursive remap with a potential remap that needs to be checked and vice-versa.
+        // In step result with 'end' we assert the result right after the keys are handled. When we use
+        // the 'endAfterTimeout' we are telling the test to wait for timeout to end and then assert the
+        // result.
+        keysPressed: ' w',
+        stepResult: {
+          end: ['|one two three'],
+          endAfterTimeout: ['one two thre|e'],
+        },
+      },
+      {
+        // Step 1: Again we press the keys '<space>w' and we assert that nothing has changed since the
+        // last result after the keys are handled.
+        keysPressed: ' w',
+        stepResult: {
+          end: ['one two thre|e'],
+        },
+      },
+      {
+        // Step 2: Since we didn't wait for timeout on the previous step it is still waiting for timeout to
+        // finish or another key to come so when we now press the key 'w' it gets '<space>ww' and remaps it
+        // to 'b'.
+        keysPressed: 'w',
+        stepResult: {
+          end: ['one two |three'],
+        },
+      },
+      {
+        // Step 3: Press keys '<space>b' that remap to '0' but since there is the '<space>bb' potential
+        // remap it waits for timeout or another key to come. Same thing as step 0 applies but in different
+        // recursiveness.
+        keysPressed: ' b',
+        stepResult: {
+          end: ['one two |three'],
+          endAfterTimeout: ['|one two three'],
+        },
+      },
+      {
+        // Step 4: Again we press the keys '<space>b' and we assert that nothing has changed since the
+        // last result after the keys are handled.
+        keysPressed: ' b',
+        stepResult: {
+          end: ['|one two three'],
+        },
+      },
+      {
+        // Step 5: Since we didn't wait for timeout on the previous step it is still waiting for timeout to
+        // finish or another key to come so when we now press the key 'b' it gets '<space>bb' and remaps it
+        // to 'w'.
+        keysPressed: 'b',
+        stepResult: {
+          end: ['one |two three'],
+        },
+      },
+      {
+        // Step 6: '<space>ee' should be handled by the RecursiveRemapper after timeout
+        keysPressed: ' ee',
+        stepResult: {
+          end: ['one |two three'],
+          endAfterTimeout: ['one e|etwo three'],
+        },
+      },
+      {
+        // Step 7: '<space>eee' should be handled by the NonRecursiveRemapper without timeout
+        keysPressed: ' eee',
+        stepResult: {
+          end: ['one eee|eetwo three'],
+        },
+      },
+      {
+        // Step 8: '<space>ll' should be handled by the NonRecursiveRemapper after timeout
+        keysPressed: ' ll',
+        stepResult: {
+          end: ['one eee|eetwo three'],
+          endAfterTimeout: ['one eeel|leetwo three'],
+        },
+      },
+      {
+        // Step 9: '<space>lll' should be handled by the RecursiveRemapper without timeout
+        keysPressed: ' lll',
+        stepResult: {
+          end: ['one eeelll|lleetwo three'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'A multiple key sequence with potential remaps on both recursiveness but without a \
+    remapping, handles all its keys after timeout',
+    start: ['|one two three'],
+    remaps: {
+      normalModeKeyBindings: [
+        {
+          before: ['x', 'x', 'x', 'x'],
+          after: ['i', '4', 'x', '<Esc>'],
+        },
+        {
+          before: ['l', 'l', 'l', 'l', 'l'],
+          after: ['i', '5', 'l', '<Esc>'],
+        },
+      ],
+      normalModeKeyBindingsNonRecursive: [
+        {
+          before: ['x', 'x', 'x', 'x', 'x'],
+          after: ['i', '5', 'x', '<Esc>'],
+        },
+        {
+          before: ['l', 'l', 'l', 'l'],
+          after: ['i', '4', 'l', '<Esc>'],
+        },
+      ],
+    },
+    steps: [
+      {
+        // Step 0: 'xxx' has no remapping and not actions so it does nothing but should still
+        // wait for timeout because of the potential remaps.
+        title: '"xxx" has no remapping but still needs to wait for timeout to finish.',
+        keysPressed: 'xxx',
+        stepResult: {
+          end: ['|one two three'],
+          endAfterTimeout: ['| two three'],
+        },
+      },
+      {
+        // Step 1: 'lll' has no remapping and not actions so it does nothing but should still
+        // wait for timeout because of the potential remaps.
+        title: '"lll" has no remapping but still needs to wait for timeout to finish.',
+        keysPressed: 'lll',
+        stepResult: {
+          end: ['| two three'],
+          endAfterTimeout: [' tw|o three'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Can handle vimrc mappings',
+    start: ['one |two three'],
+    remaps: ['nmap <leader>w w', 'nmap <leader>a <leader>w', 'nmap <leader>ww b'],
+    steps: [
+      {
+        // Step 0:
+        keysPressed: ' a',
+        stepResult: {
+          end: ['one |two three'],
+          endAfterTimeout: ['one two |three'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: "Recursive mappings where the after starts with before don't loop",
+    remaps: ['nmap ab abcd'],
+    start: ['|'],
+    steps: [
+      {
+        // Step 0:
+        keysPressed: 'ab',
+        stepResult: {
+          end: ['bcd|'],
+          endMode: Mode.Insert,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Ambiguous Mappings with a long remapping still succeed after timeout or when a key is pressed to break ambiguity',
+    remaps: [
+      'nmap ab abcdefghijklmnopqrstuvwxyz',
+      'nmap abc aAmbiguous<Esc>',
+      'imap jj <Esc>',
+      'imap jn AnotherLongAmbiguousRemap<Esc>',
+      'imap jnbn IExistJustToCreateAmbiguityWithRemainingKeys<Esc>',
+    ],
+    start: ['|'],
+    steps: [
+      {
+        // Step 0:
+        title: 'Before timeout should be equal to start and waits for timeout before remapping',
+        keysPressed: 'ab',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['bcdefghijklmnopqrstuvwxyz|'],
+          endModeAfterTimeout: Mode.Insert,
+        },
+      },
+      {
+        // Step 1:
+        title:
+          'Key given after the ambiguous remap that breaks ambiguity makes it run straight away',
+        keysPressed: '<Esc>ddab<Esc>',
+        stepResult: {
+          end: ['bcdefghijklmnopqrstuvwxy|z'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title:
+          'Key given after the ambiguous remap that breaks ambiguity makes it run straight away even if that key is itself a remap',
+        keysPressed: 'jjddabjj',
+        stepResult: {
+          end: ['bcdefghijklmnopqrstuvwxy|z'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 3:
+        title:
+          'Key given after the ambiguous remap that breaks ambiguity makes it run straight away even if that key is itself another potential remap that waits for timeout',
+        keysPressed: 'jjddabj',
+        stepResult: {
+          end: ['bcdefghijklmnopqrstuvwxyz|'],
+          endMode: Mode.Insert,
+          endAfterTimeout: ['bcdefghijklmnopqrstuvwxyzj|'],
+          endModeAfterTimeout: Mode.Insert,
+        },
+      },
+      {
+        // Step 4:
+        title:
+          'Key given after the ambiguous remap that breaks ambiguity makes it run straight away even if that key is itself another long ambiguous remap that waits for timeout and has remaining keys to be handled',
+        keysPressed: 'jjddabjnb',
+        stepResult: {
+          end: ['bcdefghijklmnopqrstuvwxyz|'],
+          endMode: Mode.Insert,
+          endAfterTimeout: ['|bcdefghijklmnopqrstuvwxyzAnotherLongAmbiguousRemap'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Remaps that call themselves run until an error',
+    remaps: ['nmap <leader>$ 0f£xA$00<Esc>', 'nmap <leader>$G <leader>$j<leader>$G'],
+    start: ['|10£', '15£', '350£', '2£', '5£'],
+    steps: [
+      {
+        // Step 0:
+        title:
+          'Calls itself until it errors (if this test fails with wrong cursor on last character instead of first it might mean that someone made the "j" fail when on last line YAY! :) if so please update this step to change the expected cursor to be on last character of last line)',
+        keysPressed: ' $G',
+        stepResult: {
+          end: ['10$00', '15$00', '350$00', '2$00', '|5$00'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title: 'Prepare for next step',
+        keysPressed: 'uG5o<Esc>gg',
+        stepResult: {
+          end: ['|10£', '15£', '350£', '2£', '5£', '', '', '', '', ''],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title:
+          'Calls itself until it errors and checks that the remaining keys that break ambiguity are not handled because they are not typed by the user',
+        keysPressed: ' $G',
+        stepResult: {
+          end: ['10$00', '15$00', '350$00', '2$00', '5$00', '|', '', '', '', ''],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Potential remaps that have remaining keys when broken should only handle those keys if typed by the user (test mentioned on remapper.ts)',
+    remaps: [
+      'nmap <leader>lf Lfill',
+      'nmap <leader>lF Lfillr',
+      'nmap Lfillc 4I<space><esc>',
+      'nmap Lfillp 2I<space><esc>',
+      'nmap Lfillrs 2I<space><esc>',
+    ],
+    start: ['|Hello World again!', 'Hello World!'],
+    steps: [
+      {
+        // Step 0:
+        title:
+          'Lfill typed by the user should handle all keys even if there is a failed action in the middle (in this case the "fi")',
+        keysPressed: 'Lfill',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', 'He|llo World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title: 'Lfill typed via remap should handle all keys if there is no failed action',
+        keysPressed: 'ai<Esc>k0 lf',
+        stepResult: {
+          end: ['|Hello World again!', 'Helilo World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', 'Helil|o World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title:
+          'Lfill typed via remap should not handle the remaining keys after a failed action in the middle (in this case the "fi")',
+        keysPressed: 'hhxk0 lf',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', '|Hello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 3:
+        title:
+          'Lfill typed via remap with a user pressed key after should run the corresponding remap',
+        keysPressed: 'k0 lfc',
+        stepResult: {
+          end: ['   | Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 4:
+        title:
+          'Lfill typed via remap with a wrong user pressed key after should not handle the keys after failed action but should handle the user pressed key',
+        keysPressed: 'j0 lfx',
+        stepResult: {
+          end: ['    Hello World again!', '|ello World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 5:
+        title:
+          'Lfill typed via remap with multiple wrong user pressed keys after should not handle the keys after failed action but should handle the user pressed keys',
+        keysPressed: ' lfrcl',
+        stepResult: {
+          end: ['    Hello World again!', 'c|llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 6:
+        title:
+          'Lfillr typed via remap with a wrong user pressed key after should not handle the keys after failed action but should handle the user pressed key',
+        keysPressed: ' lFdl',
+        stepResult: {
+          end: ['    Hello World again!', '|llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 7:
+        title:
+          'Lfill typed via remap with multiple right user pressed keys after should run the corresponding remap and the rest of the keys',
+        keysPressed: ' lfrsl',
+        stepResult: {
+          end: ['    Hello World again!', '  |llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 8:
+        title: 'Lfillrdl typed by the user should handle all the keys',
+        keysPressed: 'Lfillrdl',
+        stepResult: {
+          end: ['    Hello World again!', '  d|lo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Ambiguous remaps that have remaining keys when broken should only handle those keys if typed by the user (test mentioned on remapper.ts)',
+    remaps: [
+      'nmap <leader>lf Lfill',
+      'nmap <leader>lF Lfillr',
+      'nmap L G',
+      'nmap Lfillc 4I<space><esc>',
+      'nmap Lfillp 2I<space><esc>',
+      'nmap Lfillrs 2I<space><esc>',
+    ],
+    start: ['|Hello World again!', 'Hello World!'],
+    steps: [
+      {
+        // Step 0:
+        title:
+          'Lfill typed by the user should handle all keys even if there is a failed action in the middle (in this case the "fi")',
+        keysPressed: 'Lfill',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', 'He|llo World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title: 'Lfill typed via remap should handle all keys if there is no failed action',
+        keysPressed: 'ai<Esc>k0 lf',
+        stepResult: {
+          end: ['|Hello World again!', 'Helilo World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', 'Helil|o World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title:
+          'Lfill typed via remap should not handle the remaining keys after a failed action in the middle (in this case the "fi")',
+        keysPressed: 'hhxk0 lf',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['Hello World again!', '|Hello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 3:
+        title:
+          'Lfill typed via remap with a user pressed key after should run the corresponding remap',
+        keysPressed: 'k0 lfc',
+        stepResult: {
+          end: ['   | Hello World again!', 'Hello World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 4:
+        title:
+          'Lfill typed via remap with a wrong user pressed key after should not handle the keys after failed action but should handle the user pressed key',
+        keysPressed: 'j0 lfx',
+        stepResult: {
+          end: ['    Hello World again!', '|ello World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 5:
+        title:
+          'Lfill typed via remap with multiple wrong user pressed keys after should not handle the keys after failed action but should handle the user pressed keys',
+        keysPressed: ' lfrcl',
+        stepResult: {
+          end: ['    Hello World again!', 'c|llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 6:
+        title:
+          'Lfillr typed via remap with a wrong user pressed key after should not handle the keys after failed action but should handle the user pressed key',
+        keysPressed: ' lFdl',
+        stepResult: {
+          end: ['    Hello World again!', '|llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 7:
+        title:
+          'Lfill typed via remap with multiple right user pressed keys after should run the corresponding remap',
+        keysPressed: ' lfrsl',
+        stepResult: {
+          end: ['    Hello World again!', '  |llo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 8:
+        title: 'Lfillrdl typed by the user should handle all the keys',
+        keysPressed: 'Lfillrdl',
+        stepResult: {
+          end: ['    Hello World again!', '  d|lo World!'],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Ambiguous remaps that have remaining keys when broken should only handle those keys if typed by the user (with changing Modes)',
+    remaps: ['vmap jk <Esc>', 'vmap jkfila <Esc>', 'vmap jkff jkfil'],
+    start: ['|Hello World again!', 'Hello World!'],
+    steps: [
+      {
+        // Step 0:
+        title: 'jkfil typed by the user should handle all keys',
+        keysPressed: 'vjkfil',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Visual,
+          endAfterTimeout: ['Hello World agai|n!', 'Hello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title:
+          'jkfil typed by the user should handle all keys even if there is a failed action in the middle (in this case the "fi")',
+        keysPressed: 'j0vjkfil',
+        stepResult: {
+          end: ['Hello World again!', '|Hello World!'],
+          endMode: Mode.Visual,
+          endAfterTimeout: ['Hello World again!', 'H|ello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title: 'jkfil typed via remap should handle all keys if there is no failed action',
+        keysPressed: 'k0vjkff',
+        stepResult: {
+          end: ['|Hello World again!', 'Hello World!'],
+          endMode: Mode.Visual,
+          endAfterTimeout: ['Hello World agai|n!', 'Hello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 3:
+        title:
+          'jkfil typed via remap should not handle the remaining keys after a failed action in the middle (in this case the "fi")',
+        keysPressed: 'j0vjkff',
+        stepResult: {
+          end: ['Hello World again!', '|Hello World!'],
+          endMode: Mode.Visual,
+          endAfterTimeout: ['Hello World again!', '|Hello World!'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Non recursive remaps should stop running when they encounter a failed action',
+    remaps: ['nn <leader>a 0f£r€'],
+    start: ['|10£', '15€'],
+    steps: [
+      {
+        keysPressed: ' a',
+        stepResult: {
+          end: ['10|€', '15€'],
+        },
+      },
+      {
+        keysPressed: 'j a',
+        stepResult: {
+          end: ['10€', '|15€'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Can remap 0 and still use 0 in count',
+    remaps: ['nmap 0 dw'],
+    start: ['|one two three four five six seven eight nine ten'],
+    steps: [
+      {
+        title: 'Here 0 should be remapped',
+        keysPressed: '0',
+        stepResult: {
+          end: ['|two three four five six seven eight nine ten'],
+        },
+      },
+      {
+        title: 'Here 0 should not be remapped',
+        keysPressed: '10l',
+        stepResult: {
+          end: ['two three |four five six seven eight nine ten'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Can handle operator pending mode remaps',
+    remaps: ['omap L g_', 'ono w aw'],
+    start: ['|Just another test sentence', 'Just another test sentence'],
+    steps: [
+      {
+        keysPressed: 'dL',
+        stepResult: {
+          end: ['|', 'Just another test sentence'],
+        },
+      },
+      {
+        keysPressed: 'jldw',
+        stepResult: {
+          end: ['', '|another test sentence'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Can handle remaps with multiple keys other than the ones starting with <leader>, g or z',
+    remaps: [
+      'map ,l $', // this map creates the mapping for normal, operatorPending and visual modes
+    ],
+    start: ['|Yet another test sentence'],
+    steps: [
+      {
+        keysPressed: ',l',
+        stepResult: {
+          end: ['Yet another test sentenc|e'],
+        },
+      },
+      {
+        keysPressed: '0d,l',
+        stepResult: {
+          end: ['|'],
+        },
+      },
+      {
+        keysPressed: 'u',
+        stepResult: {
+          end: ['|Yet another test sentence'],
+        },
+      },
+      {
+        keysPressed: 'lv,ld',
+        stepResult: {
+          end: ['|Y'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Can handle d -> "_d remaps even when doing dd',
+    remaps: ['nnoremap d "_d'],
+    start: ['|one two three'],
+    steps: [
+      {
+        keysPressed: 'yww',
+        stepResult: {
+          end: ['one |two three'],
+        },
+      },
+      {
+        keysPressed: 'dw',
+        stepResult: {
+          end: ['one |three'],
+        },
+      },
+      {
+        keysPressed: 'P',
+        stepResult: {
+          end: ['one one| three'],
+        },
+      },
+      {
+        keysPressed: 'dd',
+        stepResult: {
+          end: ['|'],
+        },
+      },
+      {
+        keysPressed: 'p',
+        stepResult: {
+          end: ['one| '],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Can handle multiple insert remaps even when starting one with a leading key that is the start of another possible remap',
+    remaps: {
+      insertModeKeyBindings: [
+        {
+          before: ['q', 'r'],
+          after: ['<Esc>'],
+        },
+        {
+          before: ['t', 'h', 'r', 'u', 'n'],
+          after: [
+            't',
+            'h',
+            'r',
+            'o',
+            'w',
+            ' ',
+            '"',
+            'U',
+            'n',
+            'i',
+            'm',
+            'p',
+            'l',
+            'e',
+            'm',
+            'e',
+            'n',
+            't',
+            'e',
+            'd',
+            '"',
+            ';',
+            ' ',
+            '/',
+            '/',
+            'T',
+            'O',
+            'D',
+            'O',
+            ' ',
+            'i',
+            'm',
+            'p',
+            'l',
+            'e',
+            'm',
+            'e',
+            'n',
+            't',
+            'q',
+            'r',
+            '=',
+            '0',
+          ],
+        },
+      ],
+    },
+    start: ['|'],
+    steps: [
+      {
+        keysPressed: 'atest\nqr',
+        stepResult: {
+          end: ['test', '|'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        keysPressed: 'ithrun',
+        stepResult: {
+          end: ['test', '|throw "Unimplemented"; //TODO implement'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        keysPressed: 'itqr',
+        stepResult: {
+          end: ['test', '|tthrow "Unimplemented"; //TODO implement'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        keysPressed: 'oqthrun',
+        stepResult: {
+          end: [
+            'test',
+            'tthrow "Unimplemented"; //TODO implement',
+            '|qthrow "Unimplemented"; //TODO implement',
+          ],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Can handle remaps with ambiguous remaps on both types of recursiveness with longer NonRecursive remaps',
+    remaps: [
+      'nmap ab aab<Esc>',
+      'nmap abcdef aabcdef<Esc>',
+      'nmap abcdefghij aabcdefghi<Esc>',
+      'nnoremap abcd aabcd<Esc>',
+      'nnoremap abcdefg aabcdefg<Esc>',
+      'nnoremap abcdefgh aabcdefgh<Esc>',
+    ],
+    start: ['|'],
+    steps: [
+      {
+        // Step 0: there is no timeout because 'b' breaks ambiguity
+        title: 'Can handle "abb" has "ab" recursive remap + "b"',
+        keysPressed: 'abb',
+        stepResult: {
+          end: ['|ab'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 1: there will be timeout
+        title: 'Can handle "abcd" has "abcd" non recursive remap',
+        keysPressed: 'ddabcd',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abc|d'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 2: there will be timeout
+        title: 'Can handle "abcde" has "abcd" non recursive remap + "e"',
+        keysPressed: '0abcde',
+        stepResult: {
+          end: ['|abcd'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['aabcdbc|d'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 3: No timeout because 'x' breaks ambiguity
+        title: 'Can handle "abcdex" has "abcd" non recursive remap + "ex"',
+        keysPressed: '0abcdex',
+        stepResult: {
+          end: ['aabcdabcdb|c'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 4: there will be timeout
+        title: 'Can handle "abcdef" has "abcdef" recursive remap',
+        keysPressed: 'ddabcdef',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abcde|f'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 5: there will be timeout
+        title: 'Can handle "abcdefghi" has "abcdefgh" non recursive remap + "i"',
+        keysPressed: 'ddabcdefghi',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abcdefg|h'],
+          endModeAfterTimeout: Mode.Insert,
+        },
+      },
+      {
+        // Step 6: there will be no timeout because "x" breaks ambiguity
+        title: 'Can handle "abcdefghix" has "abcdefgh" non recursive remap + "ix"',
+        keysPressed: '<Esc>ddabcdefghix',
+        stepResult: {
+          end: ['abcdefgx|h'],
+          endMode: Mode.Insert,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Can handle remaps with ambiguous remaps on both types of recursiveness with longer Recursive remaps',
+    remaps: [
+      'nnoremap ab aab<Esc>',
+      'nnoremap abcdef aabcdef<Esc>',
+      'nnoremap abcdefghij aabcdefghi<Esc>',
+      'nmap abcd aabcd<Esc>',
+      'nmap abcdefg aabcdefg<Esc>',
+      'nmap abcdefgh aabcdefgh<Esc>',
+    ],
+    start: ['|'],
+    steps: [
+      {
+        // Step 0: there is no timeout because 'b' breaks ambiguity
+        title: 'Can handle "abb" has "ab" recursive remap + "b"',
+        keysPressed: 'abb',
+        stepResult: {
+          end: ['|ab'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 1: there will be timeout
+        title: 'Can handle "abcd" has "abcd" non recursive remap',
+        keysPressed: 'ddabcd',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abc|d'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 2: there will be timeout
+        title: 'Can handle "abcde" has "abcd" non recursive remap + "e"',
+        keysPressed: '0abcde',
+        stepResult: {
+          end: ['|abcd'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['aabcdbc|d'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 3: No timeout because 'x' breaks ambiguity
+        title: 'Can handle "abcdex" has "abcd" non recursive remap + "ex"',
+        keysPressed: '0abcdex',
+        stepResult: {
+          end: ['aabcdabcdb|c'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 4: there will be timeout
+        title: 'Can handle "abcdef" has "abcdef" recursive remap',
+        keysPressed: 'ddabcdef',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abcde|f'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 5: there will be timeout
+        title: 'Can handle "abcdefghi" has "abcdefgh" non recursive remap + "i"',
+        keysPressed: 'ddabcdefghi',
+        stepResult: {
+          end: ['|'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['abcdefg|h'],
+          endModeAfterTimeout: Mode.Insert,
+        },
+      },
+      {
+        // Step 6: there will be no timeout because "x" breaks ambiguity
+        title: 'Can handle "abcdefghix" has "abcdefgh" non recursive remap + "ix"',
+        keysPressed: '<Esc>ddabcdefghix',
+        stepResult: {
+          end: ['abcdefgx|h'],
+          endMode: Mode.Insert,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title:
+      'Can handle timeout finished with a sequence of multiple potential remaps that end on a key that waits for other keys like `f`',
+    remaps: {
+      normalModeKeyBindings: [
+        {
+          before: ['l', 'f', 'f'],
+          after: ['A', 'l', 'f', 'f', '<Esc>'],
+        },
+        {
+          before: ['l', 't'],
+          after: ['A', 'l', 't', '<Esc>'],
+        },
+      ],
+    },
+    start: ['hello |world'],
+    steps: [
+      {
+        // Step 0:
+        title: 'Can handle sequential potential remaps that waited for timeout',
+        keysPressed: 'llf',
+        stepResult: {
+          end: ['hello w|orld'],
+          endMode: Mode.Normal,
+          endAfterTimeout: ['hello wo|rld'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title:
+          'After the previous step there is no undefined key left that messes up the next action',
+        keysPressed: 'd',
+        stepResult: {
+          end: ['hello worl|d'],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Can handle a remapping right after a failed movement',
+    remaps: ['nmap j gj'],
+    start: ['|first line', 'second line'],
+    steps: [
+      {
+        // Step 0:
+        keysPressed: 'fxj',
+        stepResult: {
+          end: ['first line', '|second line'],
+        },
+      },
+    ],
+  });
+
+  newTestWithRemaps({
+    title: 'Remaps create an undo point only at the end of the remap handling',
+    remaps: [
+      'nmap <leader>$ 0f£xA$00<Esc>',
+      'nmap <leader>$G <leader>$j<leader>$G',
+      'nno <leader>a oThis is a Non Recursive Remap!<Esc>',
+    ],
+    start: ['|10£', '15£', '350£', '2£', '5£'],
+    steps: [
+      {
+        // Step 0:
+        title: 'Run remap once that executes two different steps',
+        keysPressed: ' $',
+        stepResult: {
+          end: ['|10£', '15£', '350£', '2£', '5£'],
+          endAfterTimeout: ['10$0|0', '15£', '350£', '2£', '5£'],
+          endModeAfterTimeout: Mode.Normal,
+        },
+      },
+      {
+        // Step 1:
+        title: 'Undo removes the $00 that was inserted and reinserts the deleted £ all at once',
+        keysPressed: 'u',
+        stepResult: {
+          end: ['10|£', '15£', '350£', '2£', '5£'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 2:
+        title: 'Calls itself until it errors',
+        keysPressed: ' $G',
+        stepResult: {
+          end: ['10$00', '15$00', '350$00', '2$00', '|5$00'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 3:
+        title: 'Undo should undo all the lines that were changed by the recursive remap',
+        keysPressed: 'u',
+        stepResult: {
+          end: ['10|£', '15£', '350£', '2£', '5£'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 4:
+        title: 'Make a non recursive remap',
+        keysPressed: 'G a',
+        stepResult: {
+          end: ['10£', '15£', '350£', '2£', '5£', 'This is a Non Recursive Remap|!'],
+          endMode: Mode.Normal,
+        },
+      },
+      {
+        // Step 5:
+        title: 'Undo works on NonRecursive remaps',
+        keysPressed: 'u',
+        stepResult: {
+          end: ['10£', '15£', '350£', '2£', '|5£'],
+          endMode: Mode.Normal,
+        },
+      },
+    ],
+  });
+});

--- a/test/configuration/validators/remappingValidator.test.ts
+++ b/test/configuration/validators/remappingValidator.test.ts
@@ -10,6 +10,8 @@ suite('Remapping Validator', () => {
     configuration.insertModeKeyBindingsNonRecursive = [];
     configuration.normalModeKeyBindings = [];
     configuration.normalModeKeyBindingsNonRecursive = [];
+    configuration.operatorPendingModeKeyBindings = [];
+    configuration.operatorPendingModeKeyBindingsNonRecursive = [];
     configuration.visualModeKeyBindings = [];
     configuration.visualModeKeyBindingsNonRecursive = [];
 
@@ -24,11 +26,9 @@ suite('Remapping Validator', () => {
     assert.strictEqual(actual.hasWarning, false);
 
     assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
+    assert.strictEqual(configuration.operatorPendingModeKeyBindingsMap.size, 0);
     assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
   });
 
   test('jj->esc', async () => {
@@ -57,11 +57,8 @@ suite('Remapping Validator', () => {
     assert.strictEqual(actual.hasWarning, false);
 
     assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 1);
-    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
 
     assert.strictEqual(
       configuration.insertModeKeyBindingsMap.get('jj'),
@@ -94,11 +91,8 @@ suite('Remapping Validator', () => {
     assert.strictEqual(actual.hasWarning, false);
 
     assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
   });
 
   test('remappings are de-duped', async () => {
@@ -131,10 +125,123 @@ suite('Remapping Validator', () => {
     assert.strictEqual(actual.hasWarning, true);
 
     assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.insertModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 1);
-    assert.strictEqual(configuration.normalModeKeyBindingsNonRecursiveMap.size, 0);
     assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
-    assert.strictEqual(configuration.visualModeKeyBindingsNonRecursiveMap.size, 0);
+  });
+
+  test('remappings are de-duped even when on different recursive types', async () => {
+    // setup
+    const configuration = new Configuration();
+    configuration.insertModeKeyBindings = [];
+    configuration.insertModeKeyBindingsNonRecursive = [];
+    configuration.normalModeKeyBindings = [
+      {
+        before: ['c', 'o', 'p', 'y'],
+        after: ['c', 'o', 'p', 'y'],
+      },
+    ];
+    configuration.normalModeKeyBindingsNonRecursive = [
+      {
+        before: ['c', 'o', 'p', 'y'],
+        after: ['c', 'o', 'p', 'y'],
+      },
+    ];
+    configuration.visualModeKeyBindings = [];
+    configuration.visualModeKeyBindingsNonRecursive = [];
+
+    // test
+    const validator = new RemappingValidator();
+    const actual = await validator.validate(configuration);
+
+    // assert
+    assert.strictEqual(actual.numErrors, 0);
+    assert.strictEqual(actual.hasError, false);
+    assert.strictEqual(actual.numWarnings, 1);
+    assert.strictEqual(actual.hasWarning, true);
+
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 0);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 1);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 0);
+  });
+
+  test('remappings added on different recursive types are combined in one Map', async () => {
+    // setup
+    const configuration = new Configuration();
+    configuration.insertModeKeyBindings = [
+      {
+        before: ['a'],
+        after: ['b'],
+      },
+    ];
+    configuration.insertModeKeyBindingsNonRecursive = [
+      {
+        before: ['c'],
+        after: ['d'],
+      },
+    ];
+    configuration.normalModeKeyBindings = [
+      {
+        before: ['a'],
+        after: ['b'],
+      },
+    ];
+    configuration.normalModeKeyBindingsNonRecursive = [
+      {
+        before: ['c'],
+        after: ['d'],
+      },
+    ];
+    configuration.visualModeKeyBindings = [
+      {
+        before: ['a'],
+        after: ['b'],
+      },
+    ];
+    configuration.visualModeKeyBindingsNonRecursive = [
+      {
+        before: ['c'],
+        after: ['d'],
+      },
+    ];
+    configuration.commandLineModeKeyBindings = [
+      {
+        before: ['a'],
+        after: ['b'],
+      },
+    ];
+    configuration.commandLineModeKeyBindingsNonRecursive = [
+      {
+        before: ['c'],
+        after: ['d'],
+      },
+    ];
+    configuration.operatorPendingModeKeyBindings = [
+      {
+        before: ['a'],
+        after: ['b'],
+      },
+    ];
+    configuration.operatorPendingModeKeyBindingsNonRecursive = [
+      {
+        before: ['c'],
+        after: ['d'],
+      },
+    ];
+
+    // test
+    const validator = new RemappingValidator();
+    const actual = await validator.validate(configuration);
+
+    // assert
+    assert.strictEqual(actual.numErrors, 0);
+    assert.strictEqual(actual.hasError, false);
+    assert.strictEqual(actual.numWarnings, 0);
+    assert.strictEqual(actual.hasWarning, false);
+
+    assert.strictEqual(configuration.insertModeKeyBindingsMap.size, 2);
+    assert.strictEqual(configuration.normalModeKeyBindingsMap.size, 2);
+    assert.strictEqual(configuration.visualModeKeyBindingsMap.size, 2);
+    assert.strictEqual(configuration.commandLineModeKeyBindingsMap.size, 2);
+    assert.strictEqual(configuration.operatorPendingModeKeyBindingsMap.size, 2);
   });
 });

--- a/test/configuration/vimrcKeyRemappingBuilder.test.ts
+++ b/test/configuration/vimrcKeyRemappingBuilder.test.ts
@@ -25,6 +25,26 @@ suite('VimrcKeyRemappingBuilder', () => {
         expectNull: false,
       },
       {
+        vimrcLine: 'ino jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'ino',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'nore! jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nore!',
+        expectNull: false,
+      },
+      {
         vimrcLine: 'vnoremap <leader>" c""<Esc>P',
         keyRemapping: {
           before: ['<leader>', '"'],
@@ -57,6 +77,50 @@ suite('VimrcKeyRemappingBuilder', () => {
         expectNull: false,
       },
       {
+        // Mapping with <silent> argument (argument is ignored)
+        vimrcLine: 'noremap <silent> jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'noremap',
+        expectNull: false,
+      },
+      {
+        // Mapping with <buffer> argument (argument is ignored)
+        vimrcLine: 'noremap <buffer> jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'noremap',
+        expectNull: false,
+      },
+      {
+        // Mapping with multiple arguments (arguments are ignored)
+        vimrcLine: 'noremap <buffer> <silent> jj <Esc>',
+        keyRemapping: {
+          before: ['j', 'j'],
+          after: ['<Esc>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'noremap',
+        expectNull: false,
+      },
+      {
+        // Mapping with multiple arguments with weird spacing (arguments are ignored)
+        vimrcLine: 'noremap <nowait> <silent><C-s> :w<CR>',
+        keyRemapping: {
+          before: ['<C-s>'],
+          commands: [':w'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'noremap',
+        expectNull: false,
+      },
+      {
         // Ignore non-mapping lines
         vimrcLine: 'set scrolloff=8',
         expectNull: true,
@@ -64,6 +128,21 @@ suite('VimrcKeyRemappingBuilder', () => {
       {
         // Ignore lines attempting to remap a plug in using <Plug>
         vimrcLine: 'nmap s <Plug>(easymotion-s2)',
+        expectNull: true,
+      },
+      {
+        // Ignore lines attempting to remap an expression using <expr>
+        vimrcLine: "nnoremap <expr> <Leader>o 'mm' . v:count . 'o<ESC>`m",
+        expectNull: true,
+      },
+      {
+        // Ignore lines with unmappings
+        vimrcLine: 'unmap jj',
+        expectNull: true,
+      },
+      {
+        // Ignore lines with clearmappings
+        vimrcLine: 'mapclear jj',
         expectNull: true,
       },
     ];
@@ -76,6 +155,217 @@ suite('VimrcKeyRemappingBuilder', () => {
       } else {
         assert.deepStrictEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
         assert.strictEqual(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
+      }
+    }
+  });
+  test('Build IKeyRemapping unmapping objects from .vimrc lines', async () => {
+    const testCases = [
+      {
+        vimrcLine: 'unmap <C-h>',
+        keyRemapping: {
+          before: ['<C-h>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'unmap',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'iunmap jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'iunmap',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'iun jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'iun',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'unm! jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'unm!',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'vu <leader>"',
+        keyRemapping: {
+          before: ['<leader>', '"'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'vu',
+        expectNull: false,
+      },
+      {
+        // Unmapping with <silent> argument (argument is ignored)
+        vimrcLine: 'nunmap <silent> jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nunmap',
+        expectNull: false,
+      },
+      {
+        // Unmapping with <buffer> argument (argument is ignored)
+        vimrcLine: 'nunmap <buffer> jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nunmap',
+        expectNull: false,
+      },
+      {
+        // Unmapping with multiple arguments (arguments are ignored)
+        vimrcLine: 'nunmap <buffer> <silent> jj',
+        keyRemapping: {
+          before: ['j', 'j'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nunmap',
+        expectNull: false,
+      },
+      {
+        // Unmapping with multiple arguments with weird spacing (arguments are ignored)
+        vimrcLine: 'nunmap <nowait> <silent><C-s>',
+        keyRemapping: {
+          before: ['<C-s>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'nunmap',
+        expectNull: false,
+      },
+      {
+        // Ignore non-mapping lines
+        vimrcLine: 'set scrolloff=8',
+        expectNull: true,
+      },
+      {
+        // Ignore lines with mappings
+        vimrcLine: 'imap jj <Esc>',
+        expectNull: true,
+      },
+      {
+        // Ignore lines with clearmappings
+        vimrcLine: 'mapclear jj',
+        expectNull: true,
+      },
+    ];
+
+    for (const testCase of testCases) {
+      const vimrcKeyRemapping = await vimrcKeyRemappingBuilder.buildUnmapping(testCase.vimrcLine);
+
+      if (testCase.expectNull) {
+        assert.strictEqual(vimrcKeyRemapping, undefined);
+      } else {
+        assert.deepStrictEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemapping.after, undefined);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemapping.commands, undefined);
+      }
+    }
+  });
+  test('Build IKeyRemapping clearMapping objects from .vimrc lines', async () => {
+    const testCases = [
+      {
+        vimrcLine: 'mapclear',
+        keyRemapping: {
+          before: ['<Nop>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'mapclear',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'imapc',
+        keyRemapping: {
+          before: ['<Nop>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'imapc',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'imapcl',
+        keyRemapping: {
+          before: ['<Nop>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'imapcl',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'mapclear!',
+        keyRemapping: {
+          before: ['<Nop>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'mapclear!',
+        expectNull: false,
+      },
+      {
+        vimrcLine: 'vmapc',
+        keyRemapping: {
+          before: ['<Nop>'],
+          source: 'vimrc',
+        },
+        keyRemappingType: 'vmapc',
+        expectNull: false,
+      },
+      {
+        // Clear mapping with <silent> argument (argument is ignored)
+        vimrcLine: 'mapc <silent>',
+        expectNull: true,
+      },
+      {
+        // Clear mapping with <buffer> argument (argument is ignored)
+        vimrcLine: 'nmapclear <buffer>',
+        expectNull: true,
+      },
+      {
+        // Clear mapping with multiple arguments with weird spacing (arguments are ignored)
+        vimrcLine: 'nmapc <nowait> <silent>',
+        expectNull: true,
+      },
+      {
+        // Ignore non-mapping lines
+        vimrcLine: 'set scrolloff=8',
+        expectNull: true,
+      },
+      {
+        // Ignore lines with mappings
+        vimrcLine: 'imap jj <Esc>',
+        expectNull: true,
+      },
+      {
+        // Ignore lines with unmappings
+        vimrcLine: 'unmap jj',
+        expectNull: true,
+      },
+    ];
+
+    for (const testCase of testCases) {
+      const vimrcKeyRemapping = await vimrcKeyRemappingBuilder.buildClearMapping(
+        testCase.vimrcLine
+      );
+
+      if (testCase.expectNull) {
+        assert.strictEqual(vimrcKeyRemapping, undefined);
+      } else {
+        assert.deepStrictEqual(vimrcKeyRemapping!.keyRemapping, testCase.keyRemapping);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemappingType, testCase.keyRemappingType);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemapping.after, undefined);
+        assert.strictEqual(vimrcKeyRemapping!.keyRemapping.commands, undefined);
       }
     }
   });

--- a/test/mode/modeNormal.test.ts
+++ b/test/mode/modeNormal.test.ts
@@ -15,6 +15,7 @@ suite('Mode Normal', () => {
     const configuration = new Configuration();
     configuration.tabstop = 4;
     configuration.expandtab = false;
+    configuration.whichwrap += 'b';
 
     await setupWorkspace(configuration);
     modeHandler = await getAndUpdateModeHandler();

--- a/test/plugins/camelCaseMotion.test.ts
+++ b/test/plugins/camelCaseMotion.test.ts
@@ -17,7 +17,7 @@ suite('camelCaseMotion plugin if not enabled', () => {
     title: "basic motion doesn't work",
     start: ['|camelWord'],
     keysPressed: '<leader>w',
-    end: ['|camelWord'],
+    end: ['camelWor|d'],
   });
 });
 

--- a/test/plugins/sneak.test.ts
+++ b/test/plugins/sneak.test.ts
@@ -184,4 +184,18 @@ suite('sneakReplacesF', () => {
     keysPressed: 'Fa;',
     end: ['apple', 'ban|ana', 'carrot'],
   });
+
+  newTest({
+    title: 'sneakReplacesF forward till',
+    start: ['|apple', 'banana', 'carrot'],
+    keysPressed: 'ta;',
+    end: ['apple', 'ba|nana', 'carrot'],
+  });
+
+  newTest({
+    title: 'sneakReplacesF backward till',
+    start: ['apple', 'banana', '|carrot'],
+    keysPressed: 'Ta;',
+    end: ['apple', 'bana|na', 'carrot'],
+  });
 });

--- a/test/register/register.test.ts
+++ b/test/register/register.test.ts
@@ -246,12 +246,11 @@ suite('register', () => {
     const expected = 'text-to-put-on-register';
     const vimState = new VimState(vscode.window.activeTextEditor!);
     vimState.recordedState.registerName = '0';
-    let actual: IRegisterContent;
 
     try {
       Register.put(expected, vimState);
-      actual = await Register.get(vimState);
-      assert.strictEqual(actual.text, expected);
+      const actual = await Register.get(vimState);
+      assert.strictEqual(actual?.text, expected);
     } catch (err) {
       assert.fail(err);
     }
@@ -312,15 +311,15 @@ suite('register', () => {
 
     // Register changed by forward search
     await modeHandler.handleMultipleKeyEvents('/katu\n'.split(''));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'katu');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'katu');
 
     // Register changed even if search doesn't exist
     await modeHandler.handleMultipleKeyEvents('0/notthere\n'.split(''));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'notthere');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'notthere');
 
     // Not changed if search is canceled
     await modeHandler.handleMultipleKeyEvents('0/Alaska'.split('').concat(['<Esc>']));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'notthere');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'notthere');
   });
 
   test('Search register (/) is set by backward search', async () => {
@@ -330,15 +329,15 @@ suite('register', () => {
 
     // Register changed by forward search
     await modeHandler.handleMultipleKeyEvents('?katu\n'.split(''));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'katu');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'katu');
 
     // Register changed even if search doesn't exist
     await modeHandler.handleMultipleKeyEvents('$?notthere\n'.split(''));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'notthere');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'notthere');
 
     // Not changed if search is canceled
     await modeHandler.handleMultipleKeyEvents('$?Alaska'.split('').concat(['<Esc>']));
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'notthere');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'notthere');
   });
 
   test('Search register (/) is set by star search', async () => {
@@ -347,16 +346,16 @@ suite('register', () => {
     );
 
     await modeHandler.handleKeyEvent('*');
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, '\\bWake\\b');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, '\\bWake\\b');
 
     await modeHandler.handleMultipleKeyEvents(['g', '*']);
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'Wake');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'Wake');
 
     await modeHandler.handleKeyEvent('#');
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, '\\bWake\\b');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, '\\bWake\\b');
 
     await modeHandler.handleMultipleKeyEvents(['g', '#']);
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'Wake');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'Wake');
   });
 
   test('Command register (:) is set by command line', async () => {
@@ -366,7 +365,7 @@ suite('register', () => {
     // :reg should not update the command register
     await modeHandler.handleMultipleKeyEvents(':reg\n'.split(''));
 
-    const regStr = ((await Register.get(modeHandler.vimState, ':')).text as RecordedState)
+    const regStr = ((await Register.get(modeHandler.vimState, ':'))?.text as RecordedState)
       .commandString;
     assert.strictEqual(regStr, command);
   });
@@ -384,9 +383,9 @@ suite('register', () => {
     await modeHandler.handleMultipleKeyEvents('"%yy'.split(''));
     await modeHandler.handleMultipleKeyEvents('":yy'.split(''));
 
-    assert.strictEqual((await Register.get(modeHandler.vimState, '/')).text, 'Expected for /');
-    assert.strictEqual((await Register.get(modeHandler.vimState, '.')).text, 'Expected for .');
-    assert.strictEqual((await Register.get(modeHandler.vimState, '%')).text, 'Expected for %');
-    assert.strictEqual((await Register.get(modeHandler.vimState, ':')).text, 'Expected for :');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '/'))?.text, 'Expected for /');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '.'))?.text, 'Expected for .');
+    assert.strictEqual((await Register.get(modeHandler.vimState, '%'))?.text, 'Expected for %');
+    assert.strictEqual((await Register.get(modeHandler.vimState, ':'))?.text, 'Expected for :');
   });
 });

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -5,6 +5,7 @@ import {
   IKeyRemapping,
   IModeSpecificStrings,
 } from '../src/configuration/iconfiguration';
+import { Globals } from '../src/globals';
 
 export class Configuration implements IConfiguration {
   useSystemClipboard = false;
@@ -136,4 +137,46 @@ export class Configuration implements IConfiguration {
   wrapscan = true;
   scroll = 20;
   startofline = true;
+
+  constructor() {
+    this.loadDefaultMappings();
+  }
+
+  /**
+   * The 'RegisterPluginAction' saves the default mappings to 'configuration' but it can't save them to
+   * testConfiguration as well because it is a class that can be created any time by a test suite so that
+   * it can reset the settings to default. So in order to get the default mappings, the 'RegisterPluginAction'
+   * also saves them on a global variable, and we load them from there when creating a new testConfiguration.
+   */
+  private loadDefaultMappings() {
+    // normal mode defaults
+    this.defaultnormalModeKeyBindings =
+      Globals.mockConfigurationDefaultBindings.defaultNormalModeKeyBindings;
+    this.defaultnormalModeKeyBindingsNonRecursive =
+      Globals.mockConfigurationDefaultBindings.defaultNormalModeKeyBindingsNonRecursive;
+
+    // insert mode defaults
+    this.defaultinsertModeKeyBindings =
+      Globals.mockConfigurationDefaultBindings.defaultInsertModeKeyBindings;
+    this.defaultinsertModeKeyBindingsNonRecursive =
+      Globals.mockConfigurationDefaultBindings.defaultInsertModeKeyBindingsNonRecursive;
+
+    // visual mode defaults
+    this.defaultvisualModeKeyBindings =
+      Globals.mockConfigurationDefaultBindings.defaultVisualModeKeyBindings;
+    this.defaultvisualModeKeyBindingsNonRecursive =
+      Globals.mockConfigurationDefaultBindings.defaultVisualModeKeyBindingsNonRecursive;
+
+    // command line mode defaults
+    this.defaultcommandLineModeKeyBindings =
+      Globals.mockConfigurationDefaultBindings.defaultCommandLineModeKeyBindings;
+    this.defaultcommandLineModeKeyBindingsNonRecursive =
+      Globals.mockConfigurationDefaultBindings.defaultCommandLineModeKeyBindingsNonRecursive;
+
+    // operator pending mode defaults
+    this.defaultoperatorPendingModeKeyBindings =
+      Globals.mockConfigurationDefaultBindings.defaultOperatorPendingModeKeyBindings;
+    this.defaultoperatorPendingModeKeyBindingsNonRecursive =
+      Globals.mockConfigurationDefaultBindings.defaultOperatorPendingModeKeyBindingsNonRecursive;
+  }
 }

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -114,6 +114,16 @@ export class Configuration implements IConfiguration {
   visualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   commandLineModeKeyBindings: IKeyRemapping[] = [];
   commandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultinsertModeKeyBindings: IKeyRemapping[] = [];
+  defaultinsertModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultnormalModeKeyBindings: IKeyRemapping[] = [];
+  defaultnormalModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultoperatorPendingModeKeyBindings: IKeyRemapping[] = [];
+  defaultoperatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultvisualModeKeyBindings: IKeyRemapping[] = [];
+  defaultvisualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  defaultcommandLineModeKeyBindings: IKeyRemapping[] = [];
+  defaultcommandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   insertModeKeyBindingsMap: Map<string, IKeyRemapping>;
   normalModeKeyBindingsMap: Map<string, IKeyRemapping>;
   operatorPendingModeKeyBindingsMap: Map<string, IKeyRemapping>;

--- a/test/testConfiguration.ts
+++ b/test/testConfiguration.ts
@@ -48,6 +48,7 @@ export class Configuration implements IConfiguration {
     obtainIMCmd: '',
   };
   timeout = 1000;
+  maxmapdepth = 1000;
   showcmd = true;
   showmodename = true;
   leader = '//';
@@ -107,18 +108,17 @@ export class Configuration implements IConfiguration {
   insertModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   normalModeKeyBindings: IKeyRemapping[] = [];
   normalModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
+  operatorPendingModeKeyBindings: IKeyRemapping[] = [];
+  operatorPendingModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   visualModeKeyBindings: IKeyRemapping[] = [];
   visualModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   commandLineModeKeyBindings: IKeyRemapping[] = [];
   commandLineModeKeyBindingsNonRecursive: IKeyRemapping[] = [];
   insertModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  insertModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   normalModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  normalModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
+  operatorPendingModeKeyBindingsMap: Map<string, IKeyRemapping>;
   visualModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  visualModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   commandLineModeKeyBindingsMap: Map<string, IKeyRemapping>;
-  commandLineModeKeyBindingsNonRecursiveMap: Map<string, IKeyRemapping>;
   whichwrap = '';
   wrapKeys = {};
   report = 2;

--- a/test/testSimplifier.ts
+++ b/test/testSimplifier.ts
@@ -9,6 +9,10 @@ import { ModeHandler } from '../src/mode/modeHandler';
 import { TextEditor } from '../src/textEditor';
 import { assertEqualLines, reloadConfiguration } from './testUtils';
 import { globalState } from '../src/state/globalState';
+import { IKeyRemapping } from '../src/configuration/iconfiguration';
+import * as os from 'os';
+import { VimrcImpl } from '../src/configuration/vimrc';
+import { vimrcKeyRemappingBuilder } from '../src/configuration/vimrcKeyRemappingBuilder';
 import { IConfiguration } from '../src/configuration/iconfiguration';
 
 export function getTestingFunctions() {
@@ -16,9 +20,10 @@ export function getTestingFunctions() {
     return stack ? stack.split('\n').splice(2, 1).join('\n') : 'no stack available :(';
   }
 
-  function newTestGeneric(
-    testObj: ITestObject,
-    testFunc: Mocha.TestFunction | Mocha.ExclusiveTestFunction | Mocha.PendingTestFunction
+  function newTestGeneric<T extends ITestObject | ITestWithRemapsObject>(
+    testObj: T,
+    testFunc: Mocha.TestFunction | Mocha.ExclusiveTestFunction | Mocha.PendingTestFunction,
+    innerTest: (modeHandler: ModeHandler, testObj: T) => Promise<void>
   ): void {
     const stack = new Error().stack;
     const niceStack = getNiceStack(stack);
@@ -36,7 +41,7 @@ export function getTestingFunctions() {
           await reloadConfiguration();
         }
         const mh = await getAndUpdateModeHandler();
-        await testIt(mh, testObj);
+        await innerTest(mh, testObj);
       } catch (reason) {
         reason.stack = niceStack;
         throw reason;
@@ -49,19 +54,31 @@ export function getTestingFunctions() {
     });
   }
 
-  const newTest = (testObj: ITestObject) => newTestGeneric(testObj, test);
+  const newTest = (testObj: ITestObject) => newTestGeneric(testObj, test, testIt);
 
   const newTestOnly = (testObj: ITestObject) => {
     console.warn('!!! Running single test !!!');
-    return newTestGeneric(testObj, test.only);
+    return newTestGeneric(testObj, test.only, testIt);
   };
 
-  const newTestSkip = (testObj: ITestObject) => newTestGeneric(testObj, test.skip);
+  const newTestSkip = (testObj: ITestObject) => newTestGeneric(testObj, test.skip, testIt);
+
+  const newTestWithRemaps = (testObj: ITestWithRemapsObject) =>
+    newTestGeneric(testObj, test, testItWithRemaps);
+  const newTestWithRemapsOnly = (testObj: ITestWithRemapsObject) => {
+    console.warn('!!! Running single test !!!');
+    return newTestGeneric(testObj, test.only, testItWithRemaps);
+  };
+  const newTestWithRemapsSkip = (testObj: ITestWithRemapsObject) =>
+    newTestGeneric(testObj, test.skip, testItWithRemaps);
 
   return {
     newTest,
     newTestOnly,
     newTestSkip,
+    newTestWithRemaps,
+    newTestWithRemapsOnly,
+    newTestWithRemapsSkip,
   };
 }
 
@@ -73,6 +90,37 @@ interface ITestObject {
   end: string[];
   endMode?: Mode;
   jumps?: string[];
+}
+
+type Step = {
+  title?: string;
+  keysPressed: string;
+  stepResult: {
+    end: string[];
+    endAfterTimeout?: string[];
+    endMode?: Mode;
+    endModeAfterTimeout?: Mode;
+    jumps?: string[];
+  };
+};
+
+interface ITestWithRemapsObject {
+  title: string;
+  config?: Partial<IConfiguration>;
+  start: string[];
+  remaps?:
+    | {
+        normalModeKeyBindings?: IKeyRemapping[];
+        normalModeKeyBindingsNonRecursive?: IKeyRemapping[];
+        insertModeKeyBindings?: IKeyRemapping[];
+        insertModeKeyBindingsNonRecursive?: IKeyRemapping[];
+        visualModeKeyBindings?: IKeyRemapping[];
+        visualModeKeyBindingsNonRecursive?: IKeyRemapping[];
+        operatorPendingModeKeyBindings?: IKeyRemapping[];
+        operatorPendingModeKeyBindingsNonRecursive?: IKeyRemapping[];
+      }
+    | string[];
+  steps: Step[];
 }
 
 class TestObjectHelper {
@@ -152,6 +200,147 @@ class TestObjectHelper {
     const numCharsInCursorStartLine =
       this._testObject.start[this.startPosition.line].replace('|', '').length - 1;
     const charactersToMove = this.startPosition.character;
+
+    if (linesToMove > 0) {
+      ret += Array(linesToMove + 1).join('j');
+    } else if (linesToMove < 0) {
+      ret += Array(Math.abs(linesToMove) + 1).join('k');
+    }
+
+    if (charactersToMove > 0) {
+      ret += Array(charactersToMove + 1).join('l');
+    } else if (charactersToMove < 0) {
+      ret += Array(Math.abs(charactersToMove) + 1).join('h');
+    }
+
+    return ret.split('');
+  }
+}
+
+class TestWithRemapsObjectHelper {
+  /**
+   * Position that the test says that the cursor starts at.
+   */
+  currentStepStartPosition = new Position(0, 0);
+
+  /**
+   * Position that the test says that the cursor ends at.
+   */
+  currentStepEndPosition = new Position(0, 0);
+
+  /**
+   * Position that the test says that the cursor ends at after timeout finishes.
+   */
+  currentStepEndAfterTimeoutPosition: Position | undefined;
+
+  /**
+   * Current step index
+   */
+  currentStep = 0;
+
+  private _isValid = false;
+  private _testObject: ITestWithRemapsObject;
+
+  constructor(_testObject: ITestWithRemapsObject) {
+    this._testObject = _testObject;
+
+    this.parseStep(_testObject);
+  }
+
+  public get isValid(): boolean {
+    return this._isValid;
+  }
+
+  private _setStartCursorPosition(lines: string[]): boolean {
+    const result = this._getCursorPosition(lines);
+    this.currentStepStartPosition = result.position;
+    return result.success;
+  }
+
+  private _setEndCursorPosition(lines: string[]): boolean {
+    const result = this._getCursorPosition(lines);
+    this.currentStepEndPosition = result.position;
+    return result.success;
+  }
+
+  private _setEndAfterTimeoutCursorPosition(lines: string[] | undefined): boolean {
+    if (!lines) {
+      return true;
+    }
+    const result = this._getCursorPosition(lines);
+    this.currentStepEndAfterTimeoutPosition = result.position;
+    return result.success;
+  }
+
+  private _getCursorPosition(lines: string[]): { success: boolean; position: Position } {
+    const ret = { success: false, position: new Position(0, 0) };
+    for (let i = 0; i < lines.length; i++) {
+      const columnIdx = lines[i].indexOf('|');
+      if (columnIdx >= 0) {
+        ret.position = new Position(i, columnIdx);
+        ret.success = true;
+      }
+    }
+
+    return ret;
+  }
+
+  public parseStep(t: ITestWithRemapsObject): void {
+    this._isValid = true;
+    const stepIdx = this.currentStep;
+    if (stepIdx === 0) {
+      if (!this._setStartCursorPosition(t.start)) {
+        this._isValid = false;
+        return;
+      }
+    } else {
+      const lastStepEnd =
+        t.steps[stepIdx - 1].stepResult.endAfterTimeout ?? t.steps[stepIdx - 1].stepResult.end;
+      if (!this._setStartCursorPosition(lastStepEnd)) {
+        this._isValid = false;
+        return;
+      }
+    }
+    if (!this._setEndCursorPosition(t.steps[stepIdx].stepResult.end)) {
+      this._isValid = false;
+      return;
+    }
+    if (!this._setEndAfterTimeoutCursorPosition(t.steps[stepIdx].stepResult.endAfterTimeout)) {
+      this._isValid = false;
+      return;
+    }
+  }
+
+  public asVimInputText(): string[] {
+    const ret = 'i' + this._testObject.start.join('\n').replace('|', '');
+    return ret.split('');
+  }
+
+  public asVimOutputText(afterTimeout: boolean = false): string[] {
+    const step = this._testObject.steps[this.currentStep];
+    const ret = afterTimeout
+      ? step.stepResult.endAfterTimeout!.slice(0)
+      : step.stepResult.end.slice(0);
+    const cursorLine = afterTimeout
+      ? this.currentStepEndAfterTimeoutPosition!.line
+      : this.currentStepEndPosition.line;
+    ret[cursorLine] = ret[cursorLine].replace('|', '');
+    return ret;
+  }
+
+  /**
+   * Returns a sequence of Vim movement characters 'hjkl' as a string array
+   * which will move the cursor to the start position given in the test.
+   */
+  public getKeyPressesToMoveToStartPosition(): string[] {
+    let ret = '';
+    const linesToMove = this.currentStepStartPosition.line;
+
+    const cursorPosAfterEsc =
+      this._testObject.start[this._testObject.start.length - 1].replace('|', '').length - 1;
+    const numCharsInCursorStartLine =
+      this._testObject.start[this.currentStepStartPosition.line].replace('|', '').length - 1;
+    const charactersToMove = this.currentStepStartPosition.character;
 
     if (linesToMove > 0) {
       ret += Array(linesToMove + 1).join('j');
@@ -295,6 +484,282 @@ async function testIt(modeHandler: ModeHandler, testObj: ITestObject): Promise<v
       expectedJumpPosition.toString(),
       'Incorrect jump position found'
     );
+  }
+}
+
+async function testItWithRemaps(
+  modeHandler: ModeHandler,
+  testObj: ITestWithRemapsObject
+): Promise<void> {
+  modeHandler.vimState.editor = vscode.window.activeTextEditor!;
+
+  const helper = new TestWithRemapsObjectHelper(testObj);
+  const jumpTracker = globalState.jumpTracker;
+
+  // Don't try this at home, kids.
+  (modeHandler as any).vimState.cursorPosition = new Position(0, 0);
+
+  await modeHandler.handleKeyEvent('<Esc>');
+
+  // Insert all the text as a single action.
+  await modeHandler.vimState.editor.edit((builder) => {
+    builder.insert(new Position(0, 0), testObj.start.join('\n').replace('|', ''));
+  });
+
+  await modeHandler.handleMultipleKeyEvents(['<Esc>', 'g', 'g']);
+
+  // Since we bypassed VSCodeVim to add text,
+  // we need to tell the history tracker that we added it.
+  modeHandler.vimState.historyTracker.addChange();
+  modeHandler.vimState.historyTracker.finishCurrentStep();
+
+  // move cursor to start position using 'hjkl'
+  await modeHandler.handleMultipleKeyEvents(helper.getKeyPressesToMoveToStartPosition());
+
+  // Check valid test object input
+  assert(helper.isValid, "Missing '|' in test object.");
+
+  Globals.mockModeHandler = modeHandler;
+
+  // Change remappings
+  if (testObj.remaps) {
+    if (!(testObj.remaps instanceof Array)) {
+      Globals.mockConfiguration.normalModeKeyBindings = testObj.remaps?.normalModeKeyBindings ?? [];
+      Globals.mockConfiguration.normalModeKeyBindingsNonRecursive =
+        testObj.remaps?.normalModeKeyBindingsNonRecursive ?? [];
+      Globals.mockConfiguration.insertModeKeyBindings = testObj.remaps?.insertModeKeyBindings ?? [];
+      Globals.mockConfiguration.insertModeKeyBindingsNonRecursive =
+        testObj.remaps?.insertModeKeyBindingsNonRecursive ?? [];
+      Globals.mockConfiguration.visualModeKeyBindings = testObj.remaps?.visualModeKeyBindings ?? [];
+      Globals.mockConfiguration.visualModeKeyBindingsNonRecursive =
+        testObj.remaps?.visualModeKeyBindingsNonRecursive ?? [];
+      Globals.mockConfiguration.operatorPendingModeKeyBindings =
+        testObj.remaps?.operatorPendingModeKeyBindings ?? [];
+      Globals.mockConfiguration.operatorPendingModeKeyBindingsNonRecursive =
+        testObj.remaps?.operatorPendingModeKeyBindingsNonRecursive ?? [];
+    } else {
+      await parseVimRCMappings(testObj.remaps);
+    }
+  }
+
+  const timeout = Globals.mockConfiguration.timeout;
+  const timeoutOffset = timeout / 2;
+  // Globals.mockConfiguration.timeout = timeout;
+
+  await reloadConfiguration();
+
+  for (const { step, index } of testObj.steps.map((value, i) => ({ step: value, index: i }))) {
+    let keysPressed = step.keysPressed;
+    if (process.platform === 'win32') {
+      keysPressed = keysPressed.replace(/\\n/g, '\\r\\n');
+    }
+
+    // Parse current step
+    helper.currentStep = index;
+    helper.parseStep(testObj);
+
+    const stepTitleOrIndex = step.title ? `nr. ${index} - "${step.title}"` : index;
+
+    // Check valid step object input
+    assert(helper.isValid, `Step ${stepTitleOrIndex} Missing '|' in test object.`);
+
+    jumpTracker.clearJumps();
+
+    // Checks if this step should wait for timeout or not
+    let waitsForTimeout = step.stepResult.endAfterTimeout !== undefined;
+
+    let result1: { lines: string; position: vscode.Position; endMode: Mode }[] = await new Promise(
+      async (r1Resolve, r1Reject) => {
+        let p1: Promise<{ lines: string; position: vscode.Position; endMode: Mode }> | undefined;
+        let p2: Promise<{ lines: string; position: vscode.Position; endMode: Mode }> | undefined;
+
+        let p1Start = () => {
+          return new Promise<{ lines: string; position: vscode.Position; endMode: Mode }>(
+            (p1Resolve, p1Reject) => {
+              setTimeout(() => {
+                // get lines, position and mode after half timeout finishes
+                const currentLines = TextEditor.getText();
+                const currentPosition = TextEditor.getSelection().start;
+                const currentMode = modeHandler.currentMode;
+                p1Resolve({ lines: currentLines, position: currentPosition, endMode: currentMode });
+              }, timeoutOffset);
+            }
+          );
+        };
+        let p2Start = () => {
+          return new Promise<{ lines: string; position: vscode.Position; endMode: Mode }>(
+            (p2Resolve, p2Reject) => {
+              if (waitsForTimeout) {
+                setTimeout(async () => {
+                  if (modeHandler.vimState.isCurrentlyPerformingRemapping) {
+                    // Performing a remapping, which means it started at the right time but it has not
+                    // finished yet (maybe the remapping has a lot of keys to handle) so we wait for the
+                    // remapping to finish
+                    const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+                    while (modeHandler.vimState.isCurrentlyPerformingRemapping) {
+                      // Wait a little bit longer here because the currently performing remap might have
+                      // some remaining keys to handle after it finishes performing the remap and there
+                      // might even be there some keys still to be sent that might create another remap.
+                      // Example: if you have and ambiguous remap like 'ab -> abcd' and 'abc -> abcdef'
+                      // and an insert remap like 'jj -> <Esc>' and you press 'abjj' the first 'j' breaks
+                      // the ambiguity and makes the remap start performing, but when the remap finishes
+                      // performing there is still the 'jj' to be handled and remapped.
+                      await wait(10);
+                    }
+                  }
+                  // get lines, position and mode after timeout + offset finishes
+                  const currentLines = TextEditor.getText();
+                  const currentPosition = TextEditor.getSelection().start;
+                  const currentMode = modeHandler.currentMode;
+                  p2Resolve({
+                    lines: currentLines,
+                    position: currentPosition,
+                    endMode: currentMode,
+                  });
+                }, timeout + timeoutOffset);
+              } else {
+                p2Resolve();
+              }
+            }
+          );
+        };
+        let p3: Promise<{ lines: string; position: vscode.Position; endMode: Mode }> = new Promise(
+          async (p3Resolve, p3Reject) => {
+            // Assumes key presses are single characters for now
+            await modeHandler.handleMultipleKeyEvents(tokenizeKeySequence(keysPressed));
+
+            // Only start the end check promises after the keys were handled to make sure they don't
+            // finish before all the keys are pressed. The keys handler above will resolve when the
+            // keys are handled even if it buffered some keys to wait for a timeout.
+            p1 = p1Start();
+            p2 = p2Start();
+            p3Resolve();
+          }
+        );
+        await p3;
+        await Promise.all([p1!, p2!]).then((results) => {
+          r1Resolve(results);
+        });
+      }
+    );
+
+    // Lines after keys pressed but before any timeout
+
+    // Check given end output is correct
+    const endLines = helper.asVimOutputText(false);
+    assert.strictEqual(
+      result1[0].lines,
+      endLines.join(os.EOL),
+      `Document content does not match on step ${stepTitleOrIndex}.`
+    );
+
+    // Check end cursor position
+    const actualEndPosition = result1[0].position;
+    const expectedEndPosition = helper.currentStepEndPosition;
+    assert.deepStrictEqual(
+      { line: actualEndPosition.line, character: actualEndPosition.character },
+      { line: expectedEndPosition.line, character: expectedEndPosition.character },
+      `Cursor position is wrong on step ${stepTitleOrIndex}.`
+    );
+
+    // endMode: check end mode is correct if given
+    const expectedEndMode = step.stepResult.endMode;
+    if (expectedEndMode !== undefined) {
+      const actualMode = Mode[result1[0].endMode].toUpperCase();
+      const expectedMode = Mode[expectedEndMode].toUpperCase();
+      assert.strictEqual(
+        actualMode,
+        expectedMode,
+        `Didn't enter correct mode on step ${stepTitleOrIndex}.`
+      );
+    }
+
+    if (waitsForTimeout) {
+      // After the timeout finishes (plus an offset to be sure it finished)
+      assert.notStrictEqual(result1[1], undefined);
+
+      // Check given endAfterTimeout output is correct
+      const endAfterTimeoutLines = helper.asVimOutputText(true);
+      assert.strictEqual(
+        result1[1].lines,
+        endAfterTimeoutLines.join(os.EOL),
+        `Document content does not match on step ${stepTitleOrIndex} after timeout.`
+      );
+
+      // Check endAfterTimeout cursor position
+      const actualEndAfterTimeoutPosition = result1[1].position;
+      const expectedEndAfterTimeoutPosition = helper.currentStepEndAfterTimeoutPosition!;
+      assert.deepStrictEqual(
+        {
+          line: actualEndAfterTimeoutPosition.line,
+          character: actualEndAfterTimeoutPosition.character,
+        },
+        {
+          line: expectedEndAfterTimeoutPosition.line,
+          character: expectedEndAfterTimeoutPosition.character,
+        },
+        `Cursor position is wrong on step ${stepTitleOrIndex} after Timeout.`
+      );
+
+      // endMode: check end mode is correct if given
+      const expectedEndAfterTimeoutMode = step.stepResult.endModeAfterTimeout;
+      if (expectedEndAfterTimeoutMode !== undefined) {
+        const actualMode = Mode[result1[1].endMode].toUpperCase();
+        const expectedMode = Mode[expectedEndAfterTimeoutMode].toUpperCase();
+        assert.strictEqual(
+          actualMode,
+          expectedMode,
+          `Didn't enter correct mode on step ${stepTitleOrIndex} after Timeout.`
+        );
+      }
+    }
+
+    // jumps: check jumps are correct if given
+    if (step.stepResult.jumps !== undefined) {
+      assert.deepEqual(
+        jumpTracker.jumps.map((j) => endLines[j.position.line] || '<MISSING>'),
+        step.stepResult.jumps.map((t) => t.replace('|', '')),
+        'Incorrect jumps found'
+      );
+
+      const stripBar = (text: string | undefined) => (text ? text.replace('|', '') : text);
+      const actualJumpPosition =
+        (jumpTracker.currentJump && endLines[jumpTracker.currentJump.position.line]) || '<FRONT>';
+      const expectedJumpPosition =
+        stripBar(step.stepResult.jumps.find((t) => t.includes('|'))) || '<FRONT>';
+
+      assert.deepEqual(
+        actualJumpPosition.toString(),
+        expectedJumpPosition.toString(),
+        `Incorrect jump position found on step ${stepTitleOrIndex}`
+      );
+    }
+  }
+}
+
+async function parseVimRCMappings(lines: string[]): Promise<void> {
+  const config = Globals.mockConfiguration;
+
+  // Remove all the old remappings from the .vimrc file
+  VimrcImpl.removeAllRemapsFromConfig(config);
+
+  // Add the new remappings
+  for (const line of lines) {
+    const remap = await vimrcKeyRemappingBuilder.build(line);
+    if (remap) {
+      VimrcImpl.addRemapToConfig(config, remap);
+      continue;
+    }
+    const unremap = await vimrcKeyRemappingBuilder.buildUnmapping(line);
+    if (unremap) {
+      VimrcImpl.removeRemapFromConfig(config, unremap);
+      continue;
+    }
+    const clearRemap = await vimrcKeyRemappingBuilder.buildClearMapping(line);
+    if (clearRemap) {
+      VimrcImpl.clearRemapsFromConfig(config, clearRemap);
+      continue;
+    }
   }
 }
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -14,6 +14,7 @@ import { TextEditor } from '../src/textEditor';
 import { getAndUpdateModeHandler } from '../extension';
 import { commandLine } from '../src/cmd_line/commandLine';
 import { StatusBar } from '../src/statusBar';
+import { SpecialKeys } from '../src/util/specialKeys';
 
 class TestMemento implements vscode.Memento {
   private mapping = new Map<string, any>();
@@ -145,7 +146,7 @@ const mockAndEnable = async () => {
   await vscode.commands.executeCommand('setContext', 'vim.active', true);
   const mh = await getAndUpdateModeHandler();
   Globals.mockModeHandler = mh;
-  await mh.handleKeyEvent('<ExtensionEnable>');
+  await mh.handleKeyEvent(SpecialKeys.ExtensionEnable);
 };
 
 export async function cleanUpWorkspace(): Promise<void> {


### PR DESCRIPTION
**What this PR does / why we need it**:
It creates a new way of handling plugins. Now the plugin's main actions are registered through the new `@RegisterPluginAction(pluginName)` which takes the new `BasePluginAction` with the new property `pluginActionDefaultKeys: string[]` which holds the keys that will be used to create the default remappings. The `keys` property now needs to have the plugin action name (the same as used by that plugin in Vim) as the first key, but can have more keys.

Examples:
*Plugin:* CamelCaseMotion
*Action:* Move "word"
In Vim you would do `map <leader>w <Plug>CamelCaseMotion_w`, here we have:
```typescript
@RegisterPluginAction('camelcasemotion')
class MoveCamelCaseWordBegin extends CamelCaseBaseMovement {
  pluginActionDefaultKeys = ['<leader>', 'w'];
  keys = ['<Plug>CamelCaseMotion_w'];

  public async execAction(position: Position, vimState: VimState): Promise<Position> {
```
Which when registering will create the default remapping `<leader>w` -> `<Plug>CamelCaseMotion_w`, here we handle `<Plug>CamelCaseMotion_w` as a single key.

*Plugin:* Sneak
*Action:* find 2 chars
In Vim you would do `nmap s <Plug>Sneak_s`, here we have:
```typescript
@RegisterPluginAction('sneak')
class SneakForwardNormalAndVisualMode extends SneakForward {
  keys = ['<Plug>Sneak_s', '<character>', '<character>'];
  pluginActionDefaultKeys = ['s'];
  modes = [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
}
```
Here even though we have 3 keys for the action we only map the `pluginActionDefaultKeys` to the first key of keys, so we get a remap of `s -> <Plug>Sneak_s` which when it gets to the action handler waits for two more keys of type \<character\>.

This was implemented on all plugins and since I was changing them I also added some features to them (this method actually makes it easier to add more features from these plugins) like the `<Plug>Sneak_t`, `<Plug>Sneak_T` from sneak and the keys 'cS', 'yS' (operator), 'ySs', 'ySS' (same as 'ySs') and 'gS' (visual mode) from surround plugin.

On register we create the default mappings but we add them to the mappings Maps when loading config depending on whether the plugin is active or not, we also don't add the plugin default mapping if the user already has a map for that key. Example: if the user has this map: `w` -> `<Plug>CamelCaseMotion_w` we don't create the mapping for `<leader>w`. This is a behavior that a lot of plugins do in Vim as well.

The result of all this is not only do we have a better implementation of plugins, we also get the original action of the \<leader\> key back. Now if you press the leader key it waits for timeout when it has potential mappings, but after timeout finishes it executes its original action. If you don't want to wait, you can now create a different NonRecursive mapping to the leader key. For example if you set your leader to `,`, you can do:
```json
"vim.normalModeKeyBindingsNonRecursive": [
    {
        "before": ["\\"],
        "after": [","]
    }
]
```
And this way you get the original action of `,` with the `\` key.

The next step with this is to be able to read the mappings from .vimrc that use `<Plug>`. I intend to do this by storing all the `<Plug>name` that we implement on the `RegisterPluginAction`, then the vimrc builder can use those stored implemented plugin actions to regex the vimrc for compatible plugin actions. This would mean that we would be able to read the following remaps from vimrc:
```vim
map w <Plug>CamelCaseMotion_w
omap iw <Plug>CamelCaseMotion_iw
nnoremap <leader>s" v<Plug>CamelCaseMotion_iw<Plug>VSurround"
```

**Which issue(s) this PR fixes**
fixes #4916
fixes #2027
fixes #4909
fixes #4973

**Special notes for your reviewer**:
This PR is based off of the PR #4735